### PR TITLE
Filter to override short-circuit of conditions

### DIFF
--- a/classes/Site/Restrictions.php
+++ b/classes/Site/Restrictions.php
@@ -47,10 +47,10 @@ class Restrictions {
 
 		$restrictions = Options::get( 'restrictions' );
 
-		$restriced_content = false;
+		$restricted_content = false;
 
 		if ( ! $restrictions || empty( $restrictions ) ) {
-			return $restriced_content;
+			return $restricted_content;
 		}
 
 		foreach ( $restrictions as $restriction ) {
@@ -58,7 +58,7 @@ class Restrictions {
 				$roles = ! empty( $restriction['roles'] ) ? $restriction['roles'] : array();
 
 				if ( Is::access_blocked( $restriction['who'], $roles, array( 'context' => 'content_restrictions' ) ) ) {
-					$restriced_content = $restriction;
+					$restricted_content = $restriction;
 				} else { 
 					// Override the restriction short-circuit if the filter is true.
 					// Meaning we keep looping to check if there's at least one allowed 
@@ -76,7 +76,7 @@ class Restrictions {
 			}
 		}
 
-		return $restriced_content;
+		return $restricted_content;
 	}
 
 	public static function redirect( $restriction ) {

--- a/classes/Site/Restrictions.php
+++ b/classes/Site/Restrictions.php
@@ -59,8 +59,20 @@ class Restrictions {
 
 				if ( Is::access_blocked( $restriction['who'], $roles, array( 'context' => 'content_restrictions' ) ) ) {
 					$restriced_content = $restriction;
+				} else { 
+					// Override the restriction short-circuit if the filter is true.
+					// Meaning we keep looping to check if there's at least one allowed 
+					// restriction condition further down the chain.
+					if ( apply_filters( 'content_control_override_short_circuit', '' ) ) { 
+						$restricted_content = false;
+						break;
+					}
 				}
-				break;
+				// If there's no short-circuit override, break the loop when the first
+				// blocked restriction condition is met.
+				if ( !apply_filters( 'content_control_override_short_circuit', '' ) ) {
+					break;
+				}
 			}
 		}
 


### PR DESCRIPTION
Added logic to accept a short-circuit override filter.

If the filter returns **true**, then loop through all restrictions to see if there's at least 1 allowable restriction.

**Issue**: https://github.com/JunglePlugins/Content-Control/issues/49

## Test cases

1. Created 3 restrictions with 1 role and 1 post category each. Created a post with all three categories.
2. Created 3 posts. Each post has 1 category created in test case 1.
3. Created a post with a category that has no restrictions.
4. Created a post with a category that has a logged-out restriction.

## Usage

`add_filter( 'content_control_override_short_circuit', '__return_true' );`
