### PR TITLE
Fix infinite loop conflict with Polylang

### DIFF
--- a/classes/Controllers/Frontend/Restrictions/QueryTerms.php
+++ b/classes/Controllers/Frontend/Restrictions/QueryTerms.php
@@ -95,11 +95,11 @@ class QueryTerms extends Controller {
 	 * @return \WP_Term[]
 	 */
 	public function restrict_query_terms( $terms, $taxonomy, $query_vars, $query ) {
-		if ( protection_is_disabled() ) {
+		if ( query_can_be_ignored( $query ) ) {
 			return $terms;
 		}
 
-		if ( query_can_be_ignored( $query ) ) {
+		if ( protection_is_disabled() ) {
 			return $terms;
 		}
 


### PR DESCRIPTION
Fix #107

The `get_terms` filter is quite tricky to use as the combination of plugins may result in calls to `get_terms()` hooked to this filter. This is especially true since WP is using this function more and more inside functions such as `wp_get_object_terms()` or `term_exists()`.

So the first thing to do is to restrict the code executed in the function hooked to this filter to limit as much as possible the risk of conflicts. That's why I propose to move the call to  ` query_can_be_ignored()` on top. With Poylang this is sufficient to fix the conflict as it is in `protection_is_disabled()`.

 You may have already encountered this kind of issue as `query_can_be_ignored()` [is protected against infinite loops](https://github.com/code-atlantic/content-control/blob/v2.3.0/inc/functions/restrictions.php#L176). I also see that you [are ignoring some taxonomies](https://github.com/code-atlantic/content-control/blob/v2.3.0/inc/functions/restrictions.php#L160-L163). i woudl suggest to add to your list all non-public taxonomies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved query term restrictions by prioritizing the check for ignorable queries before checking if protection is disabled. This ensures more accurate query handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->