### PR TITLE
Resolve WordPress.org automated review findings

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,7 +32,6 @@
 apigen.neon
 CHANGELOG.md
 babel.config.js
-composer.json
 composer.lock
 gulpfile.js
 labels.json

--- a/bin/verify-release-artifact.js
+++ b/bin/verify-release-artifact.js
@@ -8,6 +8,7 @@ const { execFileSync } = require( 'child_process' );
 const pluginRoot = 'content-control';
 
 const requiredPaths = [
+	'composer.json',
 	'content-control.php',
 	'readme.txt',
 	'dist/settings-page.js',

--- a/classes/Base/Stream.php
+++ b/classes/Base/Stream.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * HTTP Stream class.
+ *
+ * This class writes the `text/event-stream` wire format, not HTML. HTML
+ * escaping would corrupt SSE framing. Event names are reduced to the
+ * characters permitted by this implementation, non-string payloads are JSON
+ * encoded, and every payload line is emitted as a separate `data:` field.
+ * Content Control uses this only from capability- and nonce-protected
+ * administrative upgrade handlers.
  */
 class Stream {
 
@@ -36,7 +43,11 @@ class Stream {
 	 * @param string $stream_name Stream name.
 	 */
 	public function __construct( $stream_name = 'stream' ) {
-		$this->stream_name = $stream_name;
+		$this->stream_name = sanitize_key( $stream_name );
+
+		if ( empty( $this->stream_name ) ) {
+			$this->stream_name = 'stream';
+		}
 	}
 
 	/**
@@ -107,10 +118,8 @@ class Stream {
 	 * @return void
 	 */
 	public function send_data( $data ) {
-		$data = is_string( $data ) ? $data : \wp_json_encode( $data );
-
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
+		echo $this->format_data( $data );
 		echo PHP_EOL;
 
 		$this->flush_buffers();
@@ -125,15 +134,34 @@ class Stream {
 	 * @return void
 	 */
 	public function send_event( $event, $data = '' ) {
-		$data = is_string( $data ) ? $data : \wp_json_encode( $data );
+		$event = preg_replace( '/[^a-zA-Z0-9_.:-]/', '', (string) $event );
+		$event = empty( $event ) ? 'message' : $event;
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "event: {$event}" . PHP_EOL;
+		echo 'event: ' . $event . PHP_EOL;
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
+		echo $this->format_data( $data );
 		echo PHP_EOL;
 
 		$this->flush_buffers();
+	}
+
+	/**
+	 * Format a value as one or more SSE data fields.
+	 *
+	 * @param mixed $data Data to format.
+	 *
+	 * @return string
+	 */
+	protected function format_data( $data ) {
+		$data  = is_string( $data ) ? $data : \wp_json_encode( $data );
+		$data  = is_string( $data ) ? $data : '';
+		$data  = str_replace( [ "\r\n", "\r" ], "\n", $data );
+		$lines = explode( "\n", $data );
+
+		return implode( PHP_EOL, array_map( static function ( $line ) {
+			return 'data: ' . $line;
+		}, $lines ) ) . PHP_EOL;
 	}
 
 	/**

--- a/classes/Controllers/Admin/Reviews.php
+++ b/classes/Controllers/Admin/Reviews.php
@@ -483,20 +483,20 @@ class Reviews extends Controller {
 		<div class="notice notice-success is-dismissible content-control-notice">
 
 			<div class="notice-logo">
-				<img class="logo" width="110" src="<?php echo esc_attr( plugin()->get_url( 'assets/images/illustration-check.svg' ) ); ?>" />
+				<img class="logo" width="110" src="<?php echo esc_url( plugin()->get_url( 'assets/images/illustration-check.svg' ) ); ?>" />
 			</div>
 
 			<div class="notice-content">
 				<p>
 					<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $trigger['message'];
+					// Review messages support post-safe inline markup such as emphasis and the star-rating span.
+					echo wp_kses_post( $trigger['message'] );
 					?>
 					~ <a target="_blank" href="https://twitter.com/danieliser" title="Follow Daniel on Twitter">@danieliser</a>
 				</p>
 				<ul class="review-actions">
 					<li>😁
-						<a class="content-control-dismiss" target="_blank" href="<?php echo esc_attr( $trigger['link'] ); ?>" data-reason="am_now">
+						<a class="content-control-dismiss" target="_blank" href="<?php echo esc_url( $trigger['link'] ); ?>" data-reason="am_now">
 							<strong><?php esc_html_e( 'Ok, you deserve it', 'content-control' ); ?></strong>
 						</a>
 					</li>

--- a/classes/Controllers/Admin/Reviews.php
+++ b/classes/Controllers/Admin/Reviews.php
@@ -90,17 +90,16 @@ class Reviews extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_review_action' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_review_action' ) ) {
 			wp_send_json_error();
 		}
 
-		$args = wp_parse_args( $_REQUEST, [
-			'group'  => $this->get_trigger_group(),
-			'code'   => $this->get_trigger_code(),
-			'pri'    => $this->get_current_trigger( 'pri' ),
-			'reason' => 'maybe_later',
-		] );
+		$args = [
+			'group'  => isset( $_REQUEST['group'] ) && is_string( $_REQUEST['group'] ) ? sanitize_key( wp_unslash( $_REQUEST['group'] ) ) : $this->get_trigger_group(),
+			'code'   => isset( $_REQUEST['code'] ) && is_string( $_REQUEST['code'] ) ? sanitize_key( wp_unslash( $_REQUEST['code'] ) ) : $this->get_trigger_code(),
+			'pri'    => isset( $_REQUEST['pri'] ) && is_numeric( $_REQUEST['pri'] ) ? absint( $_REQUEST['pri'] ) : $this->get_current_trigger( 'pri' ),
+			'reason' => isset( $_REQUEST['reason'] ) && is_string( $_REQUEST['reason'] ) ? sanitize_key( wp_unslash( $_REQUEST['reason'] ) ) : 'maybe_later',
+		];
 
 		try {
 			$user_id = get_current_user_id();

--- a/classes/Controllers/Admin/Upgrades.php
+++ b/classes/Controllers/Admin/Upgrades.php
@@ -220,8 +220,7 @@ class Upgrades extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_upgrades' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_upgrades' ) ) {
 			wp_send_json_error( __( 'Invalid nonce.', 'content-control' ) );
 		}
 
@@ -322,8 +321,7 @@ class Upgrades extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler_demo() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_upgrades' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_upgrades' ) ) {
 			wp_send_json_error( __( 'Invalid nonce.', 'content-control' ) );
 		}
 

--- a/classes/Controllers/Frontend/Blocks.php
+++ b/classes/Controllers/Frontend/Blocks.php
@@ -296,81 +296,62 @@ class Blocks extends Controller {
 		$media_queries = $this->container->get_option( 'mediaQueries' );
 
 		if ( ! $media_queries ) {
-			?>
-			<style id="content-control-block-styles">
-				@media (max-width: 480px) {
-					.cc-hide-on-mobile {
-						display: none !important;
-					}
-				}
-				@media (min-width: 481px) and (max-width: 991px) {
-					.cc-hide-on-tablet {
-						display: none !important;
-					}
-				}
-				@media (min-width: 992px) {
-					.cc-hide-on-desktop {
-						display: none !important;
-					}
-				}
-			</style>
-			<?php
+			$styles  = "@media (max-width: 480px) {\n\t.cc-hide-on-mobile {\n\t\tdisplay: none !important;\n\t}\n}\n";
+			$styles .= "@media (min-width: 481px) and (max-width: 991px) {\n\t.cc-hide-on-tablet {\n\t\tdisplay: none !important;\n\t}\n}\n";
+			$styles .= "@media (min-width: 992px) {\n\t.cc-hide-on-desktop {\n\t\tdisplay: none !important;\n\t}\n}";
+			$this->enqueue_block_styles( $styles );
 			return;
 		}
 
-		$mobile_breakpoint  = isset( $media_queries['mobile'] ) ? $media_queries['mobile']['breakpoint'] : 640;
-		$tablet_breakpoint  = isset( $media_queries['tablet'] ) ? $media_queries['tablet']['breakpoint'] : 920;
-		$desktop_breakpoint = isset( $media_queries['desktop'] ) ? $media_queries['desktop']['breakpoint'] : 1440;
+		$mobile_breakpoint  = isset( $media_queries['mobile']['breakpoint'] ) ? absint( $media_queries['mobile']['breakpoint'] ) : 640;
+		$tablet_breakpoint  = isset( $media_queries['tablet']['breakpoint'] ) ? absint( $media_queries['tablet']['breakpoint'] ) : 920;
+		$desktop_breakpoint = isset( $media_queries['desktop']['breakpoint'] ) ? absint( $media_queries['desktop']['breakpoint'] ) : 1440;
 
 		$tablet_start  = $mobile_breakpoint + 1;
 		$desktop_start = $tablet_breakpoint + 1;
 
-		$styles[] = <<<CSS
-@media (max-width: {$mobile_breakpoint}px) {
-	.cc-hide-on-mobile {
-		display: none !important;
-	}
-}
-CSS;
-
-		$styles[] = <<<CSS
-@media (min-width: {$tablet_start}px) and (max-width: {$tablet_breakpoint}px) {
-	.cc-hide-on-tablet {
-		display: none !important;
-	}
-}
-CSS;
-
-		$styles[] = <<<CSS
-@media (min-width: {$desktop_start}px) and (max-width: {$desktop_breakpoint}px) {
-	.cc-hide-on-desktop {
-		display: none !important;
-	}
-}
-CSS;
+		$styles   = [];
+		$styles[] = sprintf( "@media (max-width: %dpx) {\n\t.cc-hide-on-mobile {\n\t\tdisplay: none !important;\n\t}\n}", $mobile_breakpoint );
+		$styles[] = sprintf( "@media (min-width: %dpx) and (max-width: %dpx) {\n\t.cc-hide-on-tablet {\n\t\tdisplay: none !important;\n\t}\n}", $tablet_start, $tablet_breakpoint );
+		$styles[] = sprintf( "@media (min-width: %dpx) and (max-width: %dpx) {\n\t.cc-hide-on-desktop {\n\t\tdisplay: none !important;\n\t}\n}", $desktop_start, $desktop_breakpoint );
 
 		unset( $media_queries['mobile'], $media_queries['tablet'], $media_queries['desktop'] );
 
 		foreach ( $media_queries as $media_query => $media_query_settings ) {
-			$breakpoint = $media_query_settings['breakpoint'];
+			if ( ! is_array( $media_query_settings ) || ! isset( $media_query_settings['breakpoint'] ) ) {
+				continue;
+			}
 
-			$style = <<<CSS
-@media (min-width: {$breakpoint}px) {
-	.cc-hide-on-{$media_query} {
-		display: none !important;
-	}
-}
-CSS;
+			$breakpoint        = absint( $media_query_settings['breakpoint'] );
+			$media_query_class = sanitize_html_class( $media_query );
+
+			if ( empty( $media_query_class ) ) {
+				continue;
+			}
+
+			$style = sprintf( "@media (min-width: %dpx) {\n\t.cc-hide-on-%s {\n\t\tdisplay: none !important;\n\t}\n}", $breakpoint, $media_query_class );
 
 			$styles[] = apply_filters( 'content_control/block_styles', $style, $media_query, $breakpoint );
 		}
 
 		$styles = implode( "\n", $styles );
 
-		?>
-		<style id="content-control-block-styles">
-			<?php echo $styles; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</style>
-		<?php
+		$this->enqueue_block_styles( $styles );
+	}
+
+	/**
+	 * Enqueue generated block-control styles.
+	 *
+	 * @param string $styles CSS styles.
+	 *
+	 * @return void
+	 */
+	protected function enqueue_block_styles( $styles ) {
+		$handle = 'content-control-block-styles';
+
+		wp_register_style( $handle, false, [], $this->container->get( 'version' ) );
+		wp_enqueue_style( $handle );
+		// Preserve valid HTML-like CSS syntax; wp_add_inline_style() handles style-tag safety.
+		wp_add_inline_style( $handle, $styles );
 	}
 }

--- a/classes/Controllers/Frontend/Blocks.php
+++ b/classes/Controllers/Frontend/Blocks.php
@@ -205,7 +205,7 @@ class Blocks extends Controller {
 
 			foreach ( $hide_on as $device => $hidden ) {
 				if ( $hidden ) {
-					$classes[] = 'cc-hide-on-' . esc_attr( $device );
+					$classes[] = 'cc-hide-on-' . sanitize_html_class( $device );
 				}
 			}
 		}
@@ -220,6 +220,9 @@ class Blocks extends Controller {
 		 * @return string[]
 		 */
 		$classes = apply_filters( 'content_control/get_block_control_classes', $classes, $controls, $block );
+		$classes = array_filter( $classes, 'is_string' );
+		$classes = array_map( 'sanitize_html_class', $classes );
+		$classes = array_filter( $classes );
 
 		return array_unique( $classes );
 	}
@@ -258,7 +261,7 @@ class Blocks extends Controller {
 		// Enqueue the styles.
 		// wp_enqueue_style( 'content-control-block-styles' );.
 
-		$class_name = implode( ' ', $classes );
+		$class_name = esc_attr( implode( ' ', $classes ) );
 
 		/** Mimicing WP Cores usage in https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-supports/elements.php#L32 */
 		$html_element_matches = [];

--- a/classes/Controllers/Frontend/Restrictions/PostContent.php
+++ b/classes/Controllers/Frontend/Restrictions/PostContent.php
@@ -19,6 +19,13 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class for handling global restrictions of the post contents.
  *
+ * This controller participates in WordPress's content-filter pipeline and
+ * intentionally returns rendered HTML. Restricted messages run through the
+ * same block, embed, shortcode, and media filters as `the_content`. Applying
+ * KSES after those filters would remove functional forms, embeds, SVG, and
+ * script-backed shortcode output. Values returned by the documented filters
+ * are supplied by trusted plugin/theme code.
+ *
  * @package ContentControl
  */
 class PostContent extends Controller {
@@ -111,6 +118,7 @@ class PostContent extends Controller {
 		$pre_restrict_content = apply_filters( 'content_control/pre_restrict_content', null, $content, $restriction );
 
 		if ( null !== $pre_restrict_content ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the_content.
 			return $pre_restrict_content;
 		}
 
@@ -140,6 +148,7 @@ class PostContent extends Controller {
 		 *
 		 * @return string
 		 */
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the_content.
 		return apply_filters(
 			$filter_name,
 			// If the default message is empty, show a generic message.
@@ -191,6 +200,7 @@ class PostContent extends Controller {
 		$pre_restrict_excerpt = apply_filters( 'content_control/pre_restrict_excerpt', null, $post_excerpt, $restriction );
 
 		if ( null !== $pre_restrict_excerpt ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the excerpt filter.
 			return $pre_restrict_excerpt;
 		}
 
@@ -220,6 +230,7 @@ class PostContent extends Controller {
 		 *
 		 * @return string
 		 */
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the excerpt filter.
 		return apply_filters(
 			$filter_name,
 			// If the default message is empty, show a generic message.

--- a/classes/Controllers/Shortcodes.php
+++ b/classes/Controllers/Shortcodes.php
@@ -31,6 +31,11 @@ class Shortcodes extends Controller {
 	/**
 	 * Process the [content_control] shortcode.
 	 *
+	 * When access is allowed, nested shortcode content is intentionally returned
+	 * as rendered HTML. Applying KSES after `do_shortcode()` would break forms,
+	 * embeds, SVG, and script-backed output produced by otherwise-authorized
+	 * nested shortcodes.
+	 *
 	 * @param array<string,string|int|null> $atts Array or shortcode attributes.
 	 * @param string                        $content Content inside shortcode.
 	 *
@@ -86,16 +91,19 @@ class Shortcodes extends Controller {
 			$classes[] = 'content-control-accessible';
 			// @deprecated 2.0.0
 			$classes[] = 'jp-cc-accessible';
-			$output    = do_shortcode( $content );
+			// Keep nested shortcode output intact; KSES here would strip functional rendered markup.
+			$output = do_shortcode( $content );
 		} else {
 			$classes[] = 'content-control-not-accessible';
 			// @deprecated 2.0.0
 			$classes[] = 'jp-cc-not-accessible';
-			$output    = wp_kses_post( do_shortcode( $atts['message'] ) );
+			// Denial messages are shortcode attributes and intentionally limited to post-safe HTML.
+			$output = wp_kses_post( do_shortcode( $atts['message'] ) );
 		}
 
 		$classes = implode( ' ', $classes );
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains intentional rendered nested-shortcode HTML.
 		return sprintf(
 			'<%1$s class="%2$s">%3$s</%1$s>',
 			$tag,

--- a/classes/Plugin/License.php
+++ b/classes/Plugin/License.php
@@ -14,15 +14,24 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Temporary license provider for active Pro releases older than 1.3.0.
  *
+ * Note for WordPress.org Plugin Review Team: Core registers this deprecated
+ * bridge only when it detects an active Content Control Pro version below
+ * 1.3.0. It preserves licensing and update access while that already-installed
+ * add-on is upgraded. Core alone and Pro 1.3.0 or later never instantiate it,
+ * and this class cannot install plugins.
+ *
+ * @see \ContentControl\Plugin\Core::is_legacy_pro_active()
+ *
  * @package ContentControl
  * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns licensing.
  */
 class License {
 
 	/**
-	 * EDD API URL.
+	 * Legacy EDD API URL used only for active Pro releases older than 1.3.0.
 	 *
 	 * @var string
+	 * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns licensing.
 	 */
 	const API_URL = 'https://contentcontrolplugin.com/edd-sl-api/';
 

--- a/classes/Plugin/Prerequisites.php
+++ b/classes/Plugin/Prerequisites.php
@@ -311,6 +311,7 @@ class Prerequisites {
 		$message = __( 'This plugin requires <b>%1$s %2$s</b> or higher in order to run.', 'content-control' );
 		return sprintf(
 			$message,
+			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Reuse the WordPress Core translation.
 			__( 'PHP', 'default' ),
 		$failed_check_args['version'] );
 	}
@@ -327,6 +328,7 @@ class Prerequisites {
 		$message = __( 'This plugin requires <b>%1$s %2$s</b> or higher in order to run.', 'content-control' );
 		return sprintf(
 			$message,
+			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Reuse the WordPress Core translation.
 			__( 'WordPress', 'default' ),
 			$failed_check_args['version']
 		);

--- a/classes/Plugin/Prerequisites.php
+++ b/classes/Plugin/Prerequisites.php
@@ -396,8 +396,8 @@ class Prerequisites {
 			$class   = 'notice notice-error';
 			$message = method_exists( $this, 'get_' . $failure['type'] . '_message' ) ? $this->{'get_' . $failure['type'] . '_message'}( $failure ) : false;
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), $message );
+			// Requirement messages contain only the post-safe links and emphasis generated above.
+			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), wp_kses_post( $message ) );
 		}
 	}
 }

--- a/classes/QueryMonitor/Output.php
+++ b/classes/QueryMonitor/Output.php
@@ -172,7 +172,7 @@ class Output extends QM_Output_Html {
 		// Main query restriction.
 		echo '<tr>';
 		echo '<td style="' . esc_attr( $font_style ) . '">Main Query Restriction</td>';
-		echo '<td style="' . esc_attr( $font_style ) . '">' . ( $main_query_restrictions ? '<a href="' . esc_url_raw( $main_query_restrictions->get_edit_link() ) . '" target="_blank">' . esc_html( $main_query_restrictions->title ) . '</a>' : 'None' ) . '</td>';
+		echo '<td style="' . esc_attr( $font_style ) . '">' . ( $main_query_restrictions ? '<a href="' . esc_url( $main_query_restrictions->get_edit_link() ) . '" target="_blank">' . esc_html( $main_query_restrictions->title ) . '</a>' : 'None' ) . '</td>';
 		echo '</tr>';
 
 		echo '</tbody>';
@@ -235,7 +235,7 @@ class Output extends QM_Output_Html {
 			$restrictions_html = [];
 
 			foreach ( $restrictions as $restriction ) {
-				$restrictions_html[] = '<a href="' . esc_url_raw( $restriction->get_edit_link() ) . '" target="_blank">' . esc_html( $restriction->title ) . '</a>';
+				$restrictions_html[] = '<a href="' . esc_url( $restriction->get_edit_link() ) . '" target="_blank">' . esc_html( $restriction->title ) . '</a>';
 			}
 
 			echo '<td>' . wp_kses( join( ', ', $restrictions_html ), [

--- a/classes/RestAPI/License.php
+++ b/classes/RestAPI/License.php
@@ -17,6 +17,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Temporary REST bridge for Pro releases older than 1.3.0.
  *
+ * Note for WordPress.org Plugin Review Team: these routes are registered only
+ * while Core's deprecated old-Pro license bridge is active. Every route also
+ * requires Content Control's manage-settings capability. Core-only sites and
+ * sites running Pro 1.3.0 or later do not register these routes.
+ *
+ * @see \ContentControl\Plugin\Core::is_legacy_pro_active()
+ * @see \ContentControl\Controllers\RestAPI::register_routes()
+ *
  * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns license REST routes.
  */
 class License extends WP_REST_Controller {

--- a/classes/RestAPI/ObjectSearch.php
+++ b/classes/RestAPI/ObjectSearch.php
@@ -114,7 +114,7 @@ class ObjectSearch extends WP_REST_Controller {
 		$nonce  = $request->get_param( 'nonce' );
 		$params = $request->get_params();
 
-		if ( ! isset( $nonce ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $nonce ) ), 'content_control_object_search_nonce' ) ) {
+		if ( ! isset( $nonce ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $nonce ) ), 'content_control_object_search_nonce' ) ) {
 			wp_send_json_error();
 		}
 

--- a/classes/RestAPI/ObjectSearch.php
+++ b/classes/RestAPI/ObjectSearch.php
@@ -10,6 +10,8 @@ namespace ContentControl\RestAPI;
 
 use WP_User_Query, WP_REST_Controller, WP_REST_Response, WP_REST_Server, WP_Error;
 
+use function ContentControl\plugin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -44,7 +46,7 @@ class ObjectSearch extends WP_REST_Controller {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'object_search' ],
-					'permission_callback' => '__return_true', // Read only, so anyone can view.
+					'permission_callback' => [ $this, 'object_search_permissions' ],
 					'args'                => [
 						'nonce'      => [
 							'description' => __( 'Nonce', 'content-control' ),
@@ -90,6 +92,15 @@ class ObjectSearch extends WP_REST_Controller {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Check whether the current user may search objects used by plugin settings.
+	 *
+	 * @return bool
+	 */
+	public function object_search_permissions() {
+		return current_user_can( plugin()->get_permission( 'manage_settings' ) );
 	}
 
 	/**

--- a/classes/Services/UpgradeStream.php
+++ b/classes/Services/UpgradeStream.php
@@ -98,15 +98,7 @@ class UpgradeStream extends \ContentControl\Base\Stream {
 			plugin( 'logging' )->log( $data['message'] );
 		}
 
-		$data = \wp_json_encode( $data );
-
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "event: {$event}" . PHP_EOL;
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
-		echo PHP_EOL;
-
-		$this->flush_buffers();
+		parent::send_event( $event, $data );
 	}
 
 	/**

--- a/inc/functions/content.php
+++ b/inc/functions/content.php
@@ -119,8 +119,16 @@ function get_current_page_url() {
 	global $wp;
 
 	$current_page = trailingslashit( home_url( $wp->request ) );
+	$query_args   = [];
 
-	/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash */
-	return add_query_arg( $_SERVER['QUERY_STRING'], '', $current_page );
-	/* phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash */
+	if ( isset( $_SERVER['QUERY_STRING'] ) && is_string( $_SERVER['QUERY_STRING'] ) ) {
+		// Parse before sanitizing decoded values; sanitizing the raw string removes percent encoding.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$query_string = wp_unslash( $_SERVER['QUERY_STRING'] );
+		wp_parse_str( $query_string, $query_args );
+		$query_args = map_deep( $query_args, 'sanitize_text_field' );
+		$query_args = map_deep( $query_args, 'rawurlencode' );
+	}
+
+	return add_query_arg( $query_args, $current_page );
 }

--- a/inc/functions/query.php
+++ b/inc/functions/query.php
@@ -266,7 +266,19 @@ function setup_post_globals( $post_id = null ) {
  * @since 2.4.0 - Added support for `terms` context.
  */
 function setup_term_globals( $term_id = null ) {
-	global $cc_term; // Backward compatibility.
+	/**
+	 * Legacy term context global retained for backward compatibility.
+	 *
+	 * `$cc_term` predates the managed term-context service. It remains
+	 * synchronized so existing integrations do not break, but Content Control
+	 * itself reads the managed `term` value and new integrations should do the
+	 * same.
+	 *
+	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @var \WP_Term|\WP_Error|false|null $cc_term
+	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.
+	global $cc_term;
 
 	$current_term = get_global( 'term' ); // Used instead of global $cc_term.
 
@@ -354,7 +366,19 @@ function reset_term_globals() {
 		return;
 	}
 
-	global $cc_term; // Backward compatibility.
+	/**
+	 * Legacy term context global retained for backward compatibility.
+	 *
+	 * `$cc_term` predates the managed term-context service. It remains
+	 * synchronized so existing integrations do not break, but Content Control
+	 * itself reads the managed `term` value and new integrations should do the
+	 * same.
+	 *
+	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @var \WP_Term|\WP_Error|false|null $cc_term
+	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.
+	global $cc_term;
 
 	$stored_term_id = pop_from_global( 'overloaded_terms' );
 	// Reset global post object.

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"vendor/composer/*.php",
 		"vendor/composer/*.json",
 		"vendor-prefixed/**/*",
+		"composer.json",
 		"readme.txt",
 		"index.php",
 		"content-control.php",

--- a/packages/settings-page/src/upgrades-view/index.tsx
+++ b/packages/settings-page/src/upgrades-view/index.tsx
@@ -93,7 +93,9 @@ const UpgradeView = () => {
 		( { type, data } ) => {
 			const eventData = JSON.parse( data ) as SSEvent[ 'data' ];
 
-			const { message = '', status: eventStatus } = eventData;
+			const { status: eventStatus } = eventData;
+			const message =
+				typeof eventData.message === 'string' ? eventData.message : '';
 
 			const newState = {
 				...upgradeState,
@@ -345,6 +347,7 @@ const UpgradeView = () => {
 					{ showLogs && (
 						<div className="upgrade-progress__logs">
 							<div className="upgrade-progress__logs__content">
+								{ /* Keep SSE messages in React text nodes so markup is escaped. */ }
 								{ logs.map( ( log, index ) => (
 									<div key={ index }>{ log }</div>
 								) ) }

--- a/tests/unit/Classes/Blocks.php
+++ b/tests/unit/Classes/Blocks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Block controller tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use Brain\Monkey\Functions;
+use ContentControl\Controllers\Frontend\Blocks as BlocksController;
+use ContentControl\Tests\PluginTestCase;
+
+/**
+ * Frontend block behavior.
+ */
+class Blocks extends PluginTestCase {
+
+	/**
+	 * Inline styles preserve valid HTML-like CSS syntax.
+	 */
+	public function test_inline_styles_preserve_svg_data_uris() {
+		$container  = new class() {
+			public function get( $key ) {
+				return 'version' === $key ? '2.7.0' : null;
+			}
+		};
+		$controller = new class( $container ) extends BlocksController {
+			public function enqueue_styles( $styles ) {
+				$this->enqueue_block_styles( $styles );
+			}
+		};
+		$styles     = '.icon { background-image: url("data:image/svg+xml,<svg viewBox=\'0 0 1 1\'></svg>"); }';
+
+		Functions\expect( 'wp_register_style' )
+			->once()
+			->with( 'content-control-block-styles', false, [], '2.7.0' );
+		Functions\expect( 'wp_enqueue_style' )
+			->once()
+			->with( 'content-control-block-styles' );
+		Functions\expect( 'wp_add_inline_style' )
+			->once()
+			->with( 'content-control-block-styles', $styles );
+
+		$controller->enqueue_styles( $styles );
+	}
+}

--- a/tests/unit/Classes/Shortcodes.php
+++ b/tests/unit/Classes/Shortcodes.php
@@ -39,7 +39,8 @@ class Shortcodes extends TestCase {
 			return $value;
 		} );
 		Functions\when( 'wp_kses_post' )->alias( static function ( $value ) {
-			return $value;
+			unset( $value );
+			return '[sanitized]';
 		} );
 		Functions\when( 'esc_attr' )->alias( static function ( $value ) {
 			return $value;
@@ -71,5 +72,22 @@ class Shortcodes extends TestCase {
 		$this->assertStringStartsWith( '<span ', $controller->content_control( [ 'inline' ], 'Visible' ) );
 		$this->assertStringStartsWith( '<span ', $controller->content_control( [ 'inline' => 'true' ], 'Visible' ) );
 		$this->assertStringStartsWith( '<div ', $controller->content_control( [ 'inline' => 'false' ], 'Visible' ) );
+	}
+
+	/**
+	 * Allowed nested shortcode output is not passed through post KSES.
+	 */
+	public function test_allowed_nested_shortcode_html_is_preserved() {
+		$controller = new ShortcodesController(
+			new class() {
+				public function get_option( $key, $fallback = '' ) {
+					unset( $key );
+					return $fallback;
+				}
+			}
+		);
+		$content    = '<form><input type="text"><iframe></iframe><svg></svg><script>window.example = true;</script></form>';
+
+		$this->assertStringContainsString( $content, $controller->content_control( [], $content ) );
 	}
 }

--- a/tests/unit/Classes/Stream.php
+++ b/tests/unit/Classes/Stream.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Stream controller tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use ContentControl\Base\Stream as StreamController;
+use ContentControl\Tests\TestCase;
+
+/**
+ * Server-sent event stream behavior.
+ */
+class Stream extends TestCase {
+
+	/**
+	 * Payload lines cannot inject additional SSE fields.
+	 */
+	public function test_payload_lines_are_framed_as_data_fields() {
+		$controller = new class() extends StreamController {
+			/**
+			 * Skip the WordPress-dependent stream-name setup for this formatter test.
+			 */
+			public function __construct() {}
+
+			/**
+			 * Expose the protected formatter for testing.
+			 *
+			 * @param string $data Data to format.
+			 *
+			 * @return string
+			 */
+			public function format( $data ) {
+				return $this->format_data( $data );
+			}
+		};
+
+		$payload = '</script><img src=x onerror=alert(1)>' . "\r\nevent: injected\n\ndata: forged";
+
+		$this->assertSame(
+			'data: </script><img src=x onerror=alert(1)>' . PHP_EOL .
+			'data: event: injected' . PHP_EOL .
+			'data: ' . PHP_EOL .
+			'data: data: forged' . PHP_EOL,
+			$controller->format( $payload )
+		);
+	}
+}

--- a/tests/unit/Functions/Content.php
+++ b/tests/unit/Functions/Content.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Content function tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Functions;
+
+use Brain\Monkey\Functions;
+use ContentControl\Tests\PluginTestCase;
+use Mockery;
+
+use function ContentControl\get_current_page_url;
+
+/**
+ * Content helper behavior.
+ */
+class Content extends PluginTestCase {
+
+	/**
+	 * Encoded query values are decoded before their values are sanitized.
+	 */
+	public function test_current_page_url_preserves_percent_encoded_query_values() {
+		global $wp;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture for WordPress request state.
+		$wp                      = (object) [ 'request' => 'search' ];
+		$_SERVER['QUERY_STRING'] = 's=hello%20world&filter%5Bstatus%5D=published';
+
+		Functions\when( 'home_url' )->alias( static function ( $path ) {
+			return 'https://example.com/' . ltrim( $path, '/' );
+		} );
+		Functions\when( 'trailingslashit' )->alias( static function ( $url ) {
+			return rtrim( $url, '/' ) . '/';
+		} );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->alias( static function ( $value ) {
+			return preg_replace( '/%[a-f0-9]{2}/i', '', $value );
+		} );
+		Functions\expect( 'wp_parse_str' )
+			->once()
+			->with(
+				's=hello%20world&filter%5Bstatus%5D=published',
+				Mockery::type( 'array' )
+			);
+		Functions\when( 'map_deep' )->alias( static function ( $values, $callback ) {
+			$sanitize = static function ( $value ) use ( &$sanitize, $callback ) {
+				if ( is_array( $value ) ) {
+					return array_map( $sanitize, $value );
+				}
+
+				return $callback( $value );
+			};
+
+			return $sanitize( $values );
+		} );
+		Functions\when( 'add_query_arg' )->alias( static function ( $args, $url ) {
+			return $url . '?' . http_build_query( $args );
+		} );
+
+		$this->assertSame( 'https://example.com/search/?', get_current_page_url() );
+	}
+
+	/**
+	 * Clear request globals changed by the test.
+	 */
+	protected function tearDown(): void {
+		unset( $_SERVER['QUERY_STRING'] );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

This PR is limited to the findings explicitly identified in the WordPress.org automated review email:

- include `composer.json` in the assembled WordPress.org artifact
- document and deprecate the active-old-Pro licensing compatibility bridge, including reviewer context for its external licensing API
- require administrative capability for the object-search REST endpoint
- sanitize the cited request values and query-string handling
- preserve intentional rendered `the_content` and nested shortcode HTML with narrow, documented scanner suppressions
- sanitize rendered block classes
- escape the cited admin and Query Monitor output
- harden server-sent event framing and verify the frontend keeps messages in escaped React text nodes
- replace the cited heredoc CSS
- preserve the legacy `$cc_term` compatibility global, mark it deprecated, and narrowly suppress its prefix warning

The two `default` text-domain calls remain intentional because they reuse WordPress Core translations for PHP and WordPress. They are narrowly annotated rather than changed to incorrect plugin-owned translations.

No version headers, stable tags, changelog versions, or public external-service disclosures are changed in this PR.

## Verification

- exact release-tree verification passed
- assembled artifact activated on WordPress 7.1
- object-search permissions deny anonymous access and allow administrators
- PHPStan and PHPCS passed
- focused shortcode and SSE regression tests passed
- hostile SSE markup/newlines remain inert data, and the React consumer has no raw-HTML sink

Broader proactive scanner cleanup is intentionally isolated in stacked PR #122.
