### PR TITLE
Harden WordPress.org compliance checks

### DIFF
--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -46,7 +46,6 @@ jobs:
               with:
                   build-dir: ${{ env.BUILD_DIR }}
                   slug: content-control
-                  exclude-checks: plugin_review_phpcs
                   exclude-directories: |
                       vendor
                       vendor-prefixed

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -51,7 +51,6 @@ jobs:
               with:
                   build-dir: ./build
                   slug: content-control
-                  exclude-checks: plugin_review_phpcs
                   exclude-directories: |
                       vendor
                       vendor-prefixed

--- a/classes/Controllers/Admin/WidgetEditor.php
+++ b/classes/Controllers/Admin/WidgetEditor.php
@@ -104,7 +104,7 @@ class WidgetEditor extends Controller {
 	 * @return array<string,mixed>|bool
 	 */
 	public function save( $instance, $new_instance, $old_instance ) {
-		if ( isset( $_POST['content-control-widget-editor-nonce'] ) && wp_verify_nonce( wp_unslash( sanitize_key( $_POST['content-control-widget-editor-nonce'] ) ), 'content-control-widget-editor-nonce' ) ) {
+		if ( isset( $_POST['content-control-widget-editor-nonce'] ) && is_string( $_POST['content-control-widget-editor-nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['content-control-widget-editor-nonce'] ) ), 'content-control-widget-editor-nonce' ) ) {
 			$new_instance            = parse_widget_options( $new_instance );
 			$instance['which_users'] = $new_instance['which_users'];
 			$instance['roles']       = $new_instance['roles'];

--- a/classes/Controllers/Compatibility/BetterDocs.php
+++ b/classes/Controllers/Compatibility/BetterDocs.php
@@ -60,7 +60,7 @@ class BetterDocs extends Controller {
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_REQUEST['post_type'] ) ) {
+		if ( isset( $_REQUEST['post_type'] ) && is_string( $_REQUEST['post_type'] ) ) {
 			$post_type = sanitize_text_field( wp_unslash( $_REQUEST['post_type'] ) );
 
 			// Check if any ct_forced_* request aregs are set. If so we should use the post type intent.
@@ -69,7 +69,7 @@ class BetterDocs extends Controller {
 
 				$post_type = str_replace( 'ct_forced_', '', $post_type );
 
-				$intent['name'] = explode( ':', $post_type );
+				$intent['name'] = array_values( array_filter( array_map( 'sanitize_key', explode( ':', $post_type ) ) ) );
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended

--- a/classes/Controllers/Compatibility/Divi.php
+++ b/classes/Controllers/Compatibility/Divi.php
@@ -40,10 +40,11 @@ class Divi extends Controller {
 	 * @return boolean
 	 */
 	public function protection_is_disabled( $protection_is_disabled ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['et_fb'] ) && ! empty( $_GET['et_fb'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only builder-state check.
+		if ( isset( $_GET['et_fb'] ) && is_string( $_GET['et_fb'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['et_fb'] ) ) ) {
 			return true;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return $protection_is_disabled;
 	}

--- a/classes/Controllers/Compatibility/Elementor.php
+++ b/classes/Controllers/Compatibility/Elementor.php
@@ -71,17 +71,16 @@ class Elementor extends Controller {
 	 */
 	public function elementor_builder_is_active() {
 		// Check if this is the admin theme builder app.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended Simple & direct string comparison.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only routing check.
 		if (
 			is_admin() &&
-			// Disable notices as this is a generic string comparison to prevent doing a lot of work.
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
 			! empty( $_GET['page'] ) &&
-			'elementor-app' === $_GET['page']
-			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+			is_string( $_GET['page'] ) &&
+			'elementor-app' === sanitize_key( wp_unslash( $_GET['page'] ) )
 		) {
 			return true;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( ! class_exists( '\Elementor\Plugin' ) || ! isset( \Elementor\Plugin::$instance ) ) {
 			return false;

--- a/classes/Controllers/RestAPI.php
+++ b/classes/Controllers/RestAPI.php
@@ -145,7 +145,7 @@ class RestAPI extends Controller {
 		}
 
 		// Return false if referrer is not our settings page. /wp-admin/options-general.php?page=content-control-settings.
-		if ( ! isset( $_SERVER['HTTP_REFERER'] ) ) {
+		if ( ! isset( $_SERVER['HTTP_REFERER'] ) || ! is_string( $_SERVER['HTTP_REFERER'] ) ) {
 			return false;
 		}
 

--- a/classes/Controllers/TrustedLogin.php
+++ b/classes/Controllers/TrustedLogin.php
@@ -101,10 +101,11 @@ class TrustedLogin extends Controller {
 	 * @return void
 	 */
 	public function admin_menu() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['page'] ) || 'grant-content-control-access' !== $_GET['page'] ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only routing check.
+		if ( ! isset( $_GET['page'] ) || ! is_string( $_GET['page'] ) || 'grant-content-control-access' !== sanitize_key( wp_unslash( $_GET['page'] ) ) ) {
 			return;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		add_options_page(
 			__( 'Content Control Support Access', 'content-control' ),

--- a/classes/RestAPI/BlockTypes.php
+++ b/classes/RestAPI/BlockTypes.php
@@ -48,7 +48,7 @@ class BlockTypes extends WP_REST_Controller {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_block_types' ],
-					'permission_callback' => '__return_true', // Read only, so anyone can view.
+					'permission_callback' => [ $this, 'update_block_types_permissions' ],
 				],
 				[
 					'methods'             => WP_REST_Server::EDITABLE,

--- a/inc/functions/compatibility.php
+++ b/inc/functions/compatibility.php
@@ -52,7 +52,7 @@ function is_rest() {
 	$is_rest = ( function () {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ( defined( 'REST_REQUEST' ) && REST_REQUEST )// (#1)
-			|| ( isset( $_GET['rest_route'] ) // (#2)
+			|| ( isset( $_GET['rest_route'] ) && is_string( $_GET['rest_route'] ) // (#2)
 					&& strpos( sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ), '/', 0 ) === 0 ) ) {
 				return true;
 		}
@@ -138,7 +138,7 @@ function is_frontend() {
 
 	$wp_query = $query instanceof \WP_Query ? $query : null;
 
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) && is_string( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 	if (
 		// Check if is CLI.

--- a/inc/functions/developers.php
+++ b/inc/functions/developers.php
@@ -388,16 +388,17 @@ function request_is_excluded() {
 
 	$is_excluded = false;
 
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only request classification.
 	if (
 		// Check if doing cron.
 		is_cron() ||
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		( is_ajax() && isset( $_REQUEST['action'] ) && 'heartbeat' === $_REQUEST['action'] ) ||
+		( is_ajax() && isset( $_REQUEST['action'] ) && is_string( $_REQUEST['action'] ) && 'heartbeat' === sanitize_key( wp_unslash( $_REQUEST['action'] ) ) ) ||
 		// If this is rest request and not core wp namespace.
 		( is_rest() && request_is_excluded_rest_endpoint() )
 	) {
 		$is_excluded = true;
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	return $is_excluded;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Content Control - The Ultimate Content Restriction Plugin! Restrict Content, Create Conditional Blocks & More ===
+=== Content Control - The Ultimate Content Restriction Solution! Restrict Content, Create Conditional Blocks & More ===
 Contributors: codeatlantic, danieliser
 Plugin URI: https://code-atlantic.com/?utm_campaign=upgrade-to-pro&utm_source=plugins-page&utm_medium=plugin-ui&utm_content=action-links-upgrade-text
 Author URI: https://contentcontrolplugin.com/?utm_campaign=plugin-info&utm_source=readme-header&utm_medium=plugin-ui&utm_content=author-uri

--- a/tests/unit/Classes/BetterDocs.php
+++ b/tests/unit/Classes/BetterDocs.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * BetterDocs compatibility tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use Brain\Monkey\Functions;
+use ContentControl\Controllers\Compatibility\BetterDocs as BetterDocsController;
+use ContentControl\Tests\PluginTestCase;
+
+/**
+ * BetterDocs compatibility behavior.
+ */
+class BetterDocs extends PluginTestCase {
+
+	/**
+	 * Forced post-type delimiters are preserved until each value is sanitized.
+	 */
+	public function test_forced_post_types_are_split_before_key_sanitization() {
+		global $wp;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture for WordPress request state.
+		$wp                    = (object) [ 'query_vars' => [ 'rest_route' => '/wp/v2/search' ] ];
+		$_REQUEST['post_type'] = 'ct_forced_docs:page';
+
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->alias( static function ( $value ) {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+		} );
+
+		$controller = new BetterDocsController( new \stdClass() );
+		$intent     = $controller->get_rest_api_intent( [
+			'type' => 'unknown',
+			'name' => 'search',
+		] );
+
+		$this->assertSame( 'post_type', $intent['type'] );
+		$this->assertSame( [ 'docs', 'page' ], $intent['name'] );
+	}
+
+	/**
+	 * Clear request globals changed by the test.
+	 */
+	protected function tearDown(): void {
+		unset( $_REQUEST['post_type'] );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

This stacked follow-up contains the broader cleanup found while validating the WordPress.org review response. It deliberately excludes the findings explicitly named in the review email, which remain isolated in #121.

- sanitize additional request-routing and compatibility inputs
- validate additional request value types
- restrict the administrative block-type REST endpoint
- make `plugin_review_phpcs` part of the normal PR and deployment Plugin Check gates
- remove “Plugin” from the WordPress.org listing title

No version headers, stable tags, or changelog versions are changed.

## Review order

Review and merge #121 first. This PR is based on #121 so its diff contains only the additional cleanup listed above.