### PR TITLE
Release 2.7.1

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -32,7 +32,6 @@
 apigen.neon
 CHANGELOG.md
 babel.config.js
-composer.json
 composer.lock
 gulpfile.js
 labels.json

--- a/.github/workflows/deploy-to-wordpress.yml
+++ b/.github/workflows/deploy-to-wordpress.yml
@@ -46,7 +46,6 @@ jobs:
               with:
                   build-dir: ${{ env.BUILD_DIR }}
                   slug: content-control
-                  exclude-checks: plugin_review_phpcs
                   exclude-directories: |
                       vendor
                       vendor-prefixed

--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -51,7 +51,6 @@ jobs:
               with:
                   build-dir: ./build
                   slug: content-control
-                  exclude-checks: plugin_review_phpcs
                   exclude-directories: |
                       vendor
                       vendor-prefixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v2.7.1 - 08/20/2026
+
+-   Security: Hardened administrative REST endpoints and request validation.
+-   Fix: Corrected handling of encoded query parameters in restriction return URLs.
+-   Compatibility: Improved BetterDocs searches and filtered block-control styles.
+
 ## v2.7.0 - 08/20/2026
 
 -   Feature: Added child and ancestor conditions for hierarchical taxonomies.

--- a/bin/verify-release-artifact.js
+++ b/bin/verify-release-artifact.js
@@ -8,6 +8,7 @@ const { execFileSync } = require( 'child_process' );
 const pluginRoot = 'content-control';
 
 const requiredPaths = [
+	'composer.json',
 	'content-control.php',
 	'readme.txt',
 	'dist/settings-page.js',

--- a/classes/Base/Stream.php
+++ b/classes/Base/Stream.php
@@ -13,6 +13,13 @@ defined( 'ABSPATH' ) || exit;
 
 /**
  * HTTP Stream class.
+ *
+ * This class writes the `text/event-stream` wire format, not HTML. HTML
+ * escaping would corrupt SSE framing. Event names are reduced to the
+ * characters permitted by this implementation, non-string payloads are JSON
+ * encoded, and every payload line is emitted as a separate `data:` field.
+ * Content Control uses this only from capability- and nonce-protected
+ * administrative upgrade handlers.
  */
 class Stream {
 
@@ -36,7 +43,11 @@ class Stream {
 	 * @param string $stream_name Stream name.
 	 */
 	public function __construct( $stream_name = 'stream' ) {
-		$this->stream_name = $stream_name;
+		$this->stream_name = sanitize_key( $stream_name );
+
+		if ( empty( $this->stream_name ) ) {
+			$this->stream_name = 'stream';
+		}
 	}
 
 	/**
@@ -107,10 +118,8 @@ class Stream {
 	 * @return void
 	 */
 	public function send_data( $data ) {
-		$data = is_string( $data ) ? $data : \wp_json_encode( $data );
-
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
+		echo $this->format_data( $data );
 		echo PHP_EOL;
 
 		$this->flush_buffers();
@@ -125,15 +134,34 @@ class Stream {
 	 * @return void
 	 */
 	public function send_event( $event, $data = '' ) {
-		$data = is_string( $data ) ? $data : \wp_json_encode( $data );
+		$event = preg_replace( '/[^a-zA-Z0-9_.:-]/', '', (string) $event );
+		$event = empty( $event ) ? 'message' : $event;
 
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "event: {$event}" . PHP_EOL;
+		echo 'event: ' . $event . PHP_EOL;
 		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
+		echo $this->format_data( $data );
 		echo PHP_EOL;
 
 		$this->flush_buffers();
+	}
+
+	/**
+	 * Format a value as one or more SSE data fields.
+	 *
+	 * @param mixed $data Data to format.
+	 *
+	 * @return string
+	 */
+	protected function format_data( $data ) {
+		$data  = is_string( $data ) ? $data : \wp_json_encode( $data );
+		$data  = is_string( $data ) ? $data : '';
+		$data  = str_replace( [ "\r\n", "\r" ], "\n", $data );
+		$lines = explode( "\n", $data );
+
+		return implode( PHP_EOL, array_map( static function ( $line ) {
+			return 'data: ' . $line;
+		}, $lines ) ) . PHP_EOL;
 	}
 
 	/**

--- a/classes/Controllers/Admin/Reviews.php
+++ b/classes/Controllers/Admin/Reviews.php
@@ -483,20 +483,20 @@ class Reviews extends Controller {
 		<div class="notice notice-success is-dismissible content-control-notice">
 
 			<div class="notice-logo">
-				<img class="logo" width="110" src="<?php echo esc_attr( plugin()->get_url( 'assets/images/illustration-check.svg' ) ); ?>" />
+				<img class="logo" width="110" src="<?php echo esc_url( plugin()->get_url( 'assets/images/illustration-check.svg' ) ); ?>" />
 			</div>
 
 			<div class="notice-content">
 				<p>
 					<?php
-					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-					echo $trigger['message'];
+					// Review messages support post-safe inline markup such as emphasis and the star-rating span.
+					echo wp_kses_post( $trigger['message'] );
 					?>
 					~ <a target="_blank" href="https://twitter.com/danieliser" title="Follow Daniel on Twitter">@danieliser</a>
 				</p>
 				<ul class="review-actions">
 					<li>😁
-						<a class="content-control-dismiss" target="_blank" href="<?php echo esc_attr( $trigger['link'] ); ?>" data-reason="am_now">
+						<a class="content-control-dismiss" target="_blank" href="<?php echo esc_url( $trigger['link'] ); ?>" data-reason="am_now">
 							<strong><?php esc_html_e( 'Ok, you deserve it', 'content-control' ); ?></strong>
 						</a>
 					</li>

--- a/classes/Controllers/Admin/Reviews.php
+++ b/classes/Controllers/Admin/Reviews.php
@@ -90,17 +90,16 @@ class Reviews extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_review_action' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_review_action' ) ) {
 			wp_send_json_error();
 		}
 
-		$args = wp_parse_args( $_REQUEST, [
-			'group'  => $this->get_trigger_group(),
-			'code'   => $this->get_trigger_code(),
-			'pri'    => $this->get_current_trigger( 'pri' ),
-			'reason' => 'maybe_later',
-		] );
+		$args = [
+			'group'  => isset( $_REQUEST['group'] ) && is_string( $_REQUEST['group'] ) ? sanitize_key( wp_unslash( $_REQUEST['group'] ) ) : $this->get_trigger_group(),
+			'code'   => isset( $_REQUEST['code'] ) && is_string( $_REQUEST['code'] ) ? sanitize_key( wp_unslash( $_REQUEST['code'] ) ) : $this->get_trigger_code(),
+			'pri'    => isset( $_REQUEST['pri'] ) && is_numeric( $_REQUEST['pri'] ) ? absint( $_REQUEST['pri'] ) : $this->get_current_trigger( 'pri' ),
+			'reason' => isset( $_REQUEST['reason'] ) && is_string( $_REQUEST['reason'] ) ? sanitize_key( wp_unslash( $_REQUEST['reason'] ) ) : 'maybe_later',
+		];
 
 		try {
 			$user_id = get_current_user_id();

--- a/classes/Controllers/Admin/Upgrades.php
+++ b/classes/Controllers/Admin/Upgrades.php
@@ -220,8 +220,7 @@ class Upgrades extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_upgrades' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_upgrades' ) ) {
 			wp_send_json_error( __( 'Invalid nonce.', 'content-control' ) );
 		}
 
@@ -322,8 +321,7 @@ class Upgrades extends Controller {
 	 * @return void
 	 */
 	public function ajax_handler_demo() {
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		if ( ! isset( $_REQUEST['nonce'] ) || ! wp_verify_nonce( wp_unslash( $_REQUEST['nonce'] ), 'content_control_upgrades' ) ) {
+		if ( ! isset( $_REQUEST['nonce'] ) || ! is_string( $_REQUEST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['nonce'] ) ), 'content_control_upgrades' ) ) {
 			wp_send_json_error( __( 'Invalid nonce.', 'content-control' ) );
 		}
 

--- a/classes/Controllers/Admin/WidgetEditor.php
+++ b/classes/Controllers/Admin/WidgetEditor.php
@@ -104,7 +104,7 @@ class WidgetEditor extends Controller {
 	 * @return array<string,mixed>|bool
 	 */
 	public function save( $instance, $new_instance, $old_instance ) {
-		if ( isset( $_POST['content-control-widget-editor-nonce'] ) && wp_verify_nonce( wp_unslash( sanitize_key( $_POST['content-control-widget-editor-nonce'] ) ), 'content-control-widget-editor-nonce' ) ) {
+		if ( isset( $_POST['content-control-widget-editor-nonce'] ) && is_string( $_POST['content-control-widget-editor-nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['content-control-widget-editor-nonce'] ) ), 'content-control-widget-editor-nonce' ) ) {
 			$new_instance            = parse_widget_options( $new_instance );
 			$instance['which_users'] = $new_instance['which_users'];
 			$instance['roles']       = $new_instance['roles'];

--- a/classes/Controllers/Compatibility/BetterDocs.php
+++ b/classes/Controllers/Compatibility/BetterDocs.php
@@ -60,7 +60,7 @@ class BetterDocs extends Controller {
 		}
 
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_REQUEST['post_type'] ) ) {
+		if ( isset( $_REQUEST['post_type'] ) && is_string( $_REQUEST['post_type'] ) ) {
 			$post_type = sanitize_text_field( wp_unslash( $_REQUEST['post_type'] ) );
 
 			// Check if any ct_forced_* request aregs are set. If so we should use the post type intent.
@@ -69,7 +69,7 @@ class BetterDocs extends Controller {
 
 				$post_type = str_replace( 'ct_forced_', '', $post_type );
 
-				$intent['name'] = explode( ':', $post_type );
+				$intent['name'] = array_values( array_filter( array_map( 'sanitize_key', explode( ':', $post_type ) ) ) );
 			}
 		}
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended

--- a/classes/Controllers/Compatibility/Divi.php
+++ b/classes/Controllers/Compatibility/Divi.php
@@ -40,10 +40,11 @@ class Divi extends Controller {
 	 * @return boolean
 	 */
 	public function protection_is_disabled( $protection_is_disabled ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( isset( $_GET['et_fb'] ) && ! empty( $_GET['et_fb'] ) ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only builder-state check.
+		if ( isset( $_GET['et_fb'] ) && is_string( $_GET['et_fb'] ) && '' !== sanitize_text_field( wp_unslash( $_GET['et_fb'] ) ) ) {
 			return true;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return $protection_is_disabled;
 	}

--- a/classes/Controllers/Compatibility/Elementor.php
+++ b/classes/Controllers/Compatibility/Elementor.php
@@ -71,17 +71,16 @@ class Elementor extends Controller {
 	 */
 	public function elementor_builder_is_active() {
 		// Check if this is the admin theme builder app.
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended Simple & direct string comparison.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only routing check.
 		if (
 			is_admin() &&
-			// Disable notices as this is a generic string comparison to prevent doing a lot of work.
-			// phpcs:disable WordPress.Security.NonceVerification.Recommended
 			! empty( $_GET['page'] ) &&
-			'elementor-app' === $_GET['page']
-			// phpcs:enable WordPress.Security.NonceVerification.Recommended
+			is_string( $_GET['page'] ) &&
+			'elementor-app' === sanitize_key( wp_unslash( $_GET['page'] ) )
 		) {
 			return true;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( ! class_exists( '\Elementor\Plugin' ) || ! isset( \Elementor\Plugin::$instance ) ) {
 			return false;

--- a/classes/Controllers/Frontend/Blocks.php
+++ b/classes/Controllers/Frontend/Blocks.php
@@ -296,81 +296,62 @@ class Blocks extends Controller {
 		$media_queries = $this->container->get_option( 'mediaQueries' );
 
 		if ( ! $media_queries ) {
-			?>
-			<style id="content-control-block-styles">
-				@media (max-width: 480px) {
-					.cc-hide-on-mobile {
-						display: none !important;
-					}
-				}
-				@media (min-width: 481px) and (max-width: 991px) {
-					.cc-hide-on-tablet {
-						display: none !important;
-					}
-				}
-				@media (min-width: 992px) {
-					.cc-hide-on-desktop {
-						display: none !important;
-					}
-				}
-			</style>
-			<?php
+			$styles  = "@media (max-width: 480px) {\n\t.cc-hide-on-mobile {\n\t\tdisplay: none !important;\n\t}\n}\n";
+			$styles .= "@media (min-width: 481px) and (max-width: 991px) {\n\t.cc-hide-on-tablet {\n\t\tdisplay: none !important;\n\t}\n}\n";
+			$styles .= "@media (min-width: 992px) {\n\t.cc-hide-on-desktop {\n\t\tdisplay: none !important;\n\t}\n}";
+			$this->enqueue_block_styles( $styles );
 			return;
 		}
 
-		$mobile_breakpoint  = isset( $media_queries['mobile'] ) ? $media_queries['mobile']['breakpoint'] : 640;
-		$tablet_breakpoint  = isset( $media_queries['tablet'] ) ? $media_queries['tablet']['breakpoint'] : 920;
-		$desktop_breakpoint = isset( $media_queries['desktop'] ) ? $media_queries['desktop']['breakpoint'] : 1440;
+		$mobile_breakpoint  = isset( $media_queries['mobile']['breakpoint'] ) ? absint( $media_queries['mobile']['breakpoint'] ) : 640;
+		$tablet_breakpoint  = isset( $media_queries['tablet']['breakpoint'] ) ? absint( $media_queries['tablet']['breakpoint'] ) : 920;
+		$desktop_breakpoint = isset( $media_queries['desktop']['breakpoint'] ) ? absint( $media_queries['desktop']['breakpoint'] ) : 1440;
 
 		$tablet_start  = $mobile_breakpoint + 1;
 		$desktop_start = $tablet_breakpoint + 1;
 
-		$styles[] = <<<CSS
-@media (max-width: {$mobile_breakpoint}px) {
-	.cc-hide-on-mobile {
-		display: none !important;
-	}
-}
-CSS;
-
-		$styles[] = <<<CSS
-@media (min-width: {$tablet_start}px) and (max-width: {$tablet_breakpoint}px) {
-	.cc-hide-on-tablet {
-		display: none !important;
-	}
-}
-CSS;
-
-		$styles[] = <<<CSS
-@media (min-width: {$desktop_start}px) and (max-width: {$desktop_breakpoint}px) {
-	.cc-hide-on-desktop {
-		display: none !important;
-	}
-}
-CSS;
+		$styles   = [];
+		$styles[] = sprintf( "@media (max-width: %dpx) {\n\t.cc-hide-on-mobile {\n\t\tdisplay: none !important;\n\t}\n}", $mobile_breakpoint );
+		$styles[] = sprintf( "@media (min-width: %dpx) and (max-width: %dpx) {\n\t.cc-hide-on-tablet {\n\t\tdisplay: none !important;\n\t}\n}", $tablet_start, $tablet_breakpoint );
+		$styles[] = sprintf( "@media (min-width: %dpx) and (max-width: %dpx) {\n\t.cc-hide-on-desktop {\n\t\tdisplay: none !important;\n\t}\n}", $desktop_start, $desktop_breakpoint );
 
 		unset( $media_queries['mobile'], $media_queries['tablet'], $media_queries['desktop'] );
 
 		foreach ( $media_queries as $media_query => $media_query_settings ) {
-			$breakpoint = $media_query_settings['breakpoint'];
+			if ( ! is_array( $media_query_settings ) || ! isset( $media_query_settings['breakpoint'] ) ) {
+				continue;
+			}
 
-			$style = <<<CSS
-@media (min-width: {$breakpoint}px) {
-	.cc-hide-on-{$media_query} {
-		display: none !important;
-	}
-}
-CSS;
+			$breakpoint        = absint( $media_query_settings['breakpoint'] );
+			$media_query_class = sanitize_html_class( $media_query );
+
+			if ( empty( $media_query_class ) ) {
+				continue;
+			}
+
+			$style = sprintf( "@media (min-width: %dpx) {\n\t.cc-hide-on-%s {\n\t\tdisplay: none !important;\n\t}\n}", $breakpoint, $media_query_class );
 
 			$styles[] = apply_filters( 'content_control/block_styles', $style, $media_query, $breakpoint );
 		}
 
 		$styles = implode( "\n", $styles );
 
-		?>
-		<style id="content-control-block-styles">
-			<?php echo $styles; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-		</style>
-		<?php
+		$this->enqueue_block_styles( $styles );
+	}
+
+	/**
+	 * Enqueue generated block-control styles.
+	 *
+	 * @param string $styles CSS styles.
+	 *
+	 * @return void
+	 */
+	protected function enqueue_block_styles( $styles ) {
+		$handle = 'content-control-block-styles';
+
+		wp_register_style( $handle, false, [], $this->container->get( 'version' ) );
+		wp_enqueue_style( $handle );
+		// Preserve valid HTML-like CSS syntax; wp_add_inline_style() handles style-tag safety.
+		wp_add_inline_style( $handle, $styles );
 	}
 }

--- a/classes/Controllers/Frontend/Blocks.php
+++ b/classes/Controllers/Frontend/Blocks.php
@@ -205,7 +205,7 @@ class Blocks extends Controller {
 
 			foreach ( $hide_on as $device => $hidden ) {
 				if ( $hidden ) {
-					$classes[] = 'cc-hide-on-' . esc_attr( $device );
+					$classes[] = 'cc-hide-on-' . sanitize_html_class( $device );
 				}
 			}
 		}
@@ -220,6 +220,9 @@ class Blocks extends Controller {
 		 * @return string[]
 		 */
 		$classes = apply_filters( 'content_control/get_block_control_classes', $classes, $controls, $block );
+		$classes = array_filter( $classes, 'is_string' );
+		$classes = array_map( 'sanitize_html_class', $classes );
+		$classes = array_filter( $classes );
 
 		return array_unique( $classes );
 	}
@@ -258,7 +261,7 @@ class Blocks extends Controller {
 		// Enqueue the styles.
 		// wp_enqueue_style( 'content-control-block-styles' );.
 
-		$class_name = implode( ' ', $classes );
+		$class_name = esc_attr( implode( ' ', $classes ) );
 
 		/** Mimicing WP Cores usage in https://github.com/WordPress/wordpress-develop/blob/trunk/src/wp-includes/block-supports/elements.php#L32 */
 		$html_element_matches = [];

--- a/classes/Controllers/Frontend/Restrictions/PostContent.php
+++ b/classes/Controllers/Frontend/Restrictions/PostContent.php
@@ -19,6 +19,13 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Class for handling global restrictions of the post contents.
  *
+ * This controller participates in WordPress's content-filter pipeline and
+ * intentionally returns rendered HTML. Restricted messages run through the
+ * same block, embed, shortcode, and media filters as `the_content`. Applying
+ * KSES after those filters would remove functional forms, embeds, SVG, and
+ * script-backed shortcode output. Values returned by the documented filters
+ * are supplied by trusted plugin/theme code.
+ *
  * @package ContentControl
  */
 class PostContent extends Controller {
@@ -111,6 +118,7 @@ class PostContent extends Controller {
 		$pre_restrict_content = apply_filters( 'content_control/pre_restrict_content', null, $content, $restriction );
 
 		if ( null !== $pre_restrict_content ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the_content.
 			return $pre_restrict_content;
 		}
 
@@ -140,6 +148,7 @@ class PostContent extends Controller {
 		 *
 		 * @return string
 		 */
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the_content.
 		return apply_filters(
 			$filter_name,
 			// If the default message is empty, show a generic message.
@@ -191,6 +200,7 @@ class PostContent extends Controller {
 		$pre_restrict_excerpt = apply_filters( 'content_control/pre_restrict_excerpt', null, $post_excerpt, $restriction );
 
 		if ( null !== $pre_restrict_excerpt ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the excerpt filter.
 			return $pre_restrict_excerpt;
 		}
 
@@ -220,6 +230,7 @@ class PostContent extends Controller {
 		 *
 		 * @return string
 		 */
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Intentional rendered HTML returned to the excerpt filter.
 		return apply_filters(
 			$filter_name,
 			// If the default message is empty, show a generic message.

--- a/classes/Controllers/RestAPI.php
+++ b/classes/Controllers/RestAPI.php
@@ -145,7 +145,7 @@ class RestAPI extends Controller {
 		}
 
 		// Return false if referrer is not our settings page. /wp-admin/options-general.php?page=content-control-settings.
-		if ( ! isset( $_SERVER['HTTP_REFERER'] ) ) {
+		if ( ! isset( $_SERVER['HTTP_REFERER'] ) || ! is_string( $_SERVER['HTTP_REFERER'] ) ) {
 			return false;
 		}
 

--- a/classes/Controllers/Shortcodes.php
+++ b/classes/Controllers/Shortcodes.php
@@ -31,6 +31,11 @@ class Shortcodes extends Controller {
 	/**
 	 * Process the [content_control] shortcode.
 	 *
+	 * When access is allowed, nested shortcode content is intentionally returned
+	 * as rendered HTML. Applying KSES after `do_shortcode()` would break forms,
+	 * embeds, SVG, and script-backed output produced by otherwise-authorized
+	 * nested shortcodes.
+	 *
 	 * @param array<string,string|int|null> $atts Array or shortcode attributes.
 	 * @param string                        $content Content inside shortcode.
 	 *
@@ -86,16 +91,19 @@ class Shortcodes extends Controller {
 			$classes[] = 'content-control-accessible';
 			// @deprecated 2.0.0
 			$classes[] = 'jp-cc-accessible';
-			$output    = do_shortcode( $content );
+			// Keep nested shortcode output intact; KSES here would strip functional rendered markup.
+			$output = do_shortcode( $content );
 		} else {
 			$classes[] = 'content-control-not-accessible';
 			// @deprecated 2.0.0
 			$classes[] = 'jp-cc-not-accessible';
-			$output    = wp_kses_post( do_shortcode( $atts['message'] ) );
+			// Denial messages are shortcode attributes and intentionally limited to post-safe HTML.
+			$output = wp_kses_post( do_shortcode( $atts['message'] ) );
 		}
 
 		$classes = implode( ' ', $classes );
 
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Contains intentional rendered nested-shortcode HTML.
 		return sprintf(
 			'<%1$s class="%2$s">%3$s</%1$s>',
 			$tag,

--- a/classes/Controllers/TrustedLogin.php
+++ b/classes/Controllers/TrustedLogin.php
@@ -101,10 +101,11 @@ class TrustedLogin extends Controller {
 	 * @return void
 	 */
 	public function admin_menu() {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! isset( $_GET['page'] ) || 'grant-content-control-access' !== $_GET['page'] ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only routing check.
+		if ( ! isset( $_GET['page'] ) || ! is_string( $_GET['page'] ) || 'grant-content-control-access' !== sanitize_key( wp_unslash( $_GET['page'] ) ) ) {
 			return;
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		add_options_page(
 			__( 'Content Control Support Access', 'content-control' ),

--- a/classes/Plugin/License.php
+++ b/classes/Plugin/License.php
@@ -14,15 +14,24 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Temporary license provider for active Pro releases older than 1.3.0.
  *
+ * Note for WordPress.org Plugin Review Team: Core registers this deprecated
+ * bridge only when it detects an active Content Control Pro version below
+ * 1.3.0. It preserves licensing and update access while that already-installed
+ * add-on is upgraded. Core alone and Pro 1.3.0 or later never instantiate it,
+ * and this class cannot install plugins.
+ *
+ * @see \ContentControl\Plugin\Core::is_legacy_pro_active()
+ *
  * @package ContentControl
  * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns licensing.
  */
 class License {
 
 	/**
-	 * EDD API URL.
+	 * Legacy EDD API URL used only for active Pro releases older than 1.3.0.
 	 *
 	 * @var string
+	 * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns licensing.
 	 */
 	const API_URL = 'https://contentcontrolplugin.com/edd-sl-api/';
 

--- a/classes/Plugin/Prerequisites.php
+++ b/classes/Plugin/Prerequisites.php
@@ -311,6 +311,7 @@ class Prerequisites {
 		$message = __( 'This plugin requires <b>%1$s %2$s</b> or higher in order to run.', 'content-control' );
 		return sprintf(
 			$message,
+			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Reuse the WordPress Core translation.
 			__( 'PHP', 'default' ),
 		$failed_check_args['version'] );
 	}
@@ -327,6 +328,7 @@ class Prerequisites {
 		$message = __( 'This plugin requires <b>%1$s %2$s</b> or higher in order to run.', 'content-control' );
 		return sprintf(
 			$message,
+			// phpcs:ignore WordPress.WP.I18n.TextDomainMismatch -- Reuse the WordPress Core translation.
 			__( 'WordPress', 'default' ),
 			$failed_check_args['version']
 		);

--- a/classes/Plugin/Prerequisites.php
+++ b/classes/Plugin/Prerequisites.php
@@ -396,8 +396,8 @@ class Prerequisites {
 			$class   = 'notice notice-error';
 			$message = method_exists( $this, 'get_' . $failure['type'] . '_message' ) ? $this->{'get_' . $failure['type'] . '_message'}( $failure ) : false;
 
-			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), $message );
+			// Requirement messages contain only the post-safe links and emphasis generated above.
+			printf( '<div class="%1$s"><p>%2$s</p></div>', esc_attr( $class ), wp_kses_post( $message ) );
 		}
 	}
 }

--- a/classes/QueryMonitor/Output.php
+++ b/classes/QueryMonitor/Output.php
@@ -172,7 +172,7 @@ class Output extends QM_Output_Html {
 		// Main query restriction.
 		echo '<tr>';
 		echo '<td style="' . esc_attr( $font_style ) . '">Main Query Restriction</td>';
-		echo '<td style="' . esc_attr( $font_style ) . '">' . ( $main_query_restrictions ? '<a href="' . esc_url_raw( $main_query_restrictions->get_edit_link() ) . '" target="_blank">' . esc_html( $main_query_restrictions->title ) . '</a>' : 'None' ) . '</td>';
+		echo '<td style="' . esc_attr( $font_style ) . '">' . ( $main_query_restrictions ? '<a href="' . esc_url( $main_query_restrictions->get_edit_link() ) . '" target="_blank">' . esc_html( $main_query_restrictions->title ) . '</a>' : 'None' ) . '</td>';
 		echo '</tr>';
 
 		echo '</tbody>';
@@ -235,7 +235,7 @@ class Output extends QM_Output_Html {
 			$restrictions_html = [];
 
 			foreach ( $restrictions as $restriction ) {
-				$restrictions_html[] = '<a href="' . esc_url_raw( $restriction->get_edit_link() ) . '" target="_blank">' . esc_html( $restriction->title ) . '</a>';
+				$restrictions_html[] = '<a href="' . esc_url( $restriction->get_edit_link() ) . '" target="_blank">' . esc_html( $restriction->title ) . '</a>';
 			}
 
 			echo '<td>' . wp_kses( join( ', ', $restrictions_html ), [

--- a/classes/RestAPI/BlockTypes.php
+++ b/classes/RestAPI/BlockTypes.php
@@ -48,7 +48,7 @@ class BlockTypes extends WP_REST_Controller {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'get_block_types' ],
-					'permission_callback' => '__return_true', // Read only, so anyone can view.
+					'permission_callback' => [ $this, 'update_block_types_permissions' ],
 				],
 				[
 					'methods'             => WP_REST_Server::EDITABLE,

--- a/classes/RestAPI/License.php
+++ b/classes/RestAPI/License.php
@@ -17,6 +17,14 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Temporary REST bridge for Pro releases older than 1.3.0.
  *
+ * Note for WordPress.org Plugin Review Team: these routes are registered only
+ * while Core's deprecated old-Pro license bridge is active. Every route also
+ * requires Content Control's manage-settings capability. Core-only sites and
+ * sites running Pro 1.3.0 or later do not register these routes.
+ *
+ * @see \ContentControl\Plugin\Core::is_legacy_pro_active()
+ * @see \ContentControl\Controllers\RestAPI::register_routes()
+ *
  * @deprecated 2.7.0 Content Control Pro 1.3.0+ owns license REST routes.
  */
 class License extends WP_REST_Controller {

--- a/classes/RestAPI/ObjectSearch.php
+++ b/classes/RestAPI/ObjectSearch.php
@@ -114,7 +114,7 @@ class ObjectSearch extends WP_REST_Controller {
 		$nonce  = $request->get_param( 'nonce' );
 		$params = $request->get_params();
 
-		if ( ! isset( $nonce ) || ! wp_verify_nonce( sanitize_key( wp_unslash( $nonce ) ), 'content_control_object_search_nonce' ) ) {
+		if ( ! isset( $nonce ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $nonce ) ), 'content_control_object_search_nonce' ) ) {
 			wp_send_json_error();
 		}
 

--- a/classes/RestAPI/ObjectSearch.php
+++ b/classes/RestAPI/ObjectSearch.php
@@ -10,6 +10,8 @@ namespace ContentControl\RestAPI;
 
 use WP_User_Query, WP_REST_Controller, WP_REST_Response, WP_REST_Server, WP_Error;
 
+use function ContentControl\plugin;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -44,7 +46,7 @@ class ObjectSearch extends WP_REST_Controller {
 				[
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => [ $this, 'object_search' ],
-					'permission_callback' => '__return_true', // Read only, so anyone can view.
+					'permission_callback' => [ $this, 'object_search_permissions' ],
 					'args'                => [
 						'nonce'      => [
 							'description' => __( 'Nonce', 'content-control' ),
@@ -90,6 +92,15 @@ class ObjectSearch extends WP_REST_Controller {
 				],
 			]
 		);
+	}
+
+	/**
+	 * Check whether the current user may search objects used by plugin settings.
+	 *
+	 * @return bool
+	 */
+	public function object_search_permissions() {
+		return current_user_can( plugin()->get_permission( 'manage_settings' ) );
 	}
 
 	/**

--- a/classes/Services/UpgradeStream.php
+++ b/classes/Services/UpgradeStream.php
@@ -98,15 +98,7 @@ class UpgradeStream extends \ContentControl\Base\Stream {
 			plugin( 'logging' )->log( $data['message'] );
 		}
 
-		$data = \wp_json_encode( $data );
-
-        // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "event: {$event}" . PHP_EOL;
-		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo "data: {$data}" . PHP_EOL;
-		echo PHP_EOL;
-
-		$this->flush_buffers();
+		parent::send_event( $event, $data );
 	}
 
 	/**

--- a/content-control.php
+++ b/content-control.php
@@ -3,7 +3,7 @@
  * Plugin Name: Content Control
  * Plugin URI: https://contentcontrolplugin.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=plugin-uri
  * Description: Restrict content to logged in/out users or specific user roles. Restrict access to certain parts of a page/post. Control the visibility of widgets.
- * Version: 2.7.0
+ * Version: 2.7.1
  * Author: Code Atlantic
  * Author URI: https://code-atlantic.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=author-uri
  * Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=donate-link
@@ -32,7 +32,7 @@ function get_plugin_config() {
 	return [
 		'name'          => 'Content Control',
 		'slug'          => 'content-control',
-		'version'       => '2.7.0',
+		'version'       => '2.7.1',
 		'option_prefix' => 'content_control',
 		// Maybe remove this and simply prefix `name` with `'Popup Maker'`.
 		'text_domain'   => 'content-control',

--- a/inc/functions/compatibility.php
+++ b/inc/functions/compatibility.php
@@ -52,7 +52,7 @@ function is_rest() {
 	$is_rest = ( function () {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if ( ( defined( 'REST_REQUEST' ) && REST_REQUEST )// (#1)
-			|| ( isset( $_GET['rest_route'] ) // (#2)
+			|| ( isset( $_GET['rest_route'] ) && is_string( $_GET['rest_route'] ) // (#2)
 					&& strpos( sanitize_text_field( wp_unslash( $_GET['rest_route'] ) ), '/', 0 ) === 0 ) ) {
 				return true;
 		}
@@ -138,7 +138,7 @@ function is_frontend() {
 
 	$wp_query = $query instanceof \WP_Query ? $query : null;
 
-	$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+	$request_uri = isset( $_SERVER['REQUEST_URI'] ) && is_string( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
 	if (
 		// Check if is CLI.

--- a/inc/functions/content.php
+++ b/inc/functions/content.php
@@ -119,8 +119,16 @@ function get_current_page_url() {
 	global $wp;
 
 	$current_page = trailingslashit( home_url( $wp->request ) );
+	$query_args   = [];
 
-	/* phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash */
-	return add_query_arg( $_SERVER['QUERY_STRING'], '', $current_page );
-	/* phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash */
+	if ( isset( $_SERVER['QUERY_STRING'] ) && is_string( $_SERVER['QUERY_STRING'] ) ) {
+		// Parse before sanitizing decoded values; sanitizing the raw string removes percent encoding.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$query_string = wp_unslash( $_SERVER['QUERY_STRING'] );
+		wp_parse_str( $query_string, $query_args );
+		$query_args = map_deep( $query_args, 'sanitize_text_field' );
+		$query_args = map_deep( $query_args, 'rawurlencode' );
+	}
+
+	return add_query_arg( $query_args, $current_page );
 }

--- a/inc/functions/developers.php
+++ b/inc/functions/developers.php
@@ -388,16 +388,17 @@ function request_is_excluded() {
 
 	$is_excluded = false;
 
+	// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Read-only request classification.
 	if (
 		// Check if doing cron.
 		is_cron() ||
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		( is_ajax() && isset( $_REQUEST['action'] ) && 'heartbeat' === $_REQUEST['action'] ) ||
+		( is_ajax() && isset( $_REQUEST['action'] ) && is_string( $_REQUEST['action'] ) && 'heartbeat' === sanitize_key( wp_unslash( $_REQUEST['action'] ) ) ) ||
 		// If this is rest request and not core wp namespace.
 		( is_rest() && request_is_excluded_rest_endpoint() )
 	) {
 		$is_excluded = true;
 	}
+	// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 	return $is_excluded;
 }

--- a/inc/functions/query.php
+++ b/inc/functions/query.php
@@ -274,7 +274,7 @@ function setup_term_globals( $term_id = null ) {
 	 * itself reads the managed `term` value and new integrations should do the
 	 * same.
 	 *
-	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @deprecated 2.7.1 Use get_global( 'term' ) instead.
 	 * @var \WP_Term|\WP_Error|false|null $cc_term
 	 */
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.
@@ -374,7 +374,7 @@ function reset_term_globals() {
 	 * itself reads the managed `term` value and new integrations should do the
 	 * same.
 	 *
-	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @deprecated 2.7.1 Use get_global( 'term' ) instead.
 	 * @var \WP_Term|\WP_Error|false|null $cc_term
 	 */
 	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.

--- a/inc/functions/query.php
+++ b/inc/functions/query.php
@@ -266,7 +266,19 @@ function setup_post_globals( $post_id = null ) {
  * @since 2.4.0 - Added support for `terms` context.
  */
 function setup_term_globals( $term_id = null ) {
-	global $cc_term; // Backward compatibility.
+	/**
+	 * Legacy term context global retained for backward compatibility.
+	 *
+	 * `$cc_term` predates the managed term-context service. It remains
+	 * synchronized so existing integrations do not break, but Content Control
+	 * itself reads the managed `term` value and new integrations should do the
+	 * same.
+	 *
+	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @var \WP_Term|\WP_Error|false|null $cc_term
+	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.
+	global $cc_term;
 
 	$current_term = get_global( 'term' ); // Used instead of global $cc_term.
 
@@ -354,7 +366,19 @@ function reset_term_globals() {
 		return;
 	}
 
-	global $cc_term; // Backward compatibility.
+	/**
+	 * Legacy term context global retained for backward compatibility.
+	 *
+	 * `$cc_term` predates the managed term-context service. It remains
+	 * synchronized so existing integrations do not break, but Content Control
+	 * itself reads the managed `term` value and new integrations should do the
+	 * same.
+	 *
+	 * @deprecated 2.7.0 Use get_global( 'term' ) instead.
+	 * @var \WP_Term|\WP_Error|false|null $cc_term
+	 */
+	// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound -- Deprecated compatibility global.
+	global $cc_term;
 
 	$stored_term_id = pop_from_global( 'overloaded_terms' );
 	// Reset global post object.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "content-control",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "content-control",
-			"version": "2.7.0",
+			"version": "2.7.1",
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./packages/*"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
 		"vendor/composer/*.php",
 		"vendor/composer/*.json",
 		"vendor-prefixed/**/*",
+		"composer.json",
 		"readme.txt",
 		"index.php",
 		"content-control.php",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "content-control",
-	"version": "2.7.0",
+	"version": "2.7.1",
 	"description": "",
 	"author": "Code Atlantic LLC",
 	"license": "GPL-2.0-or-later",

--- a/packages/settings-page/src/upgrades-view/index.tsx
+++ b/packages/settings-page/src/upgrades-view/index.tsx
@@ -93,7 +93,9 @@ const UpgradeView = () => {
 		( { type, data } ) => {
 			const eventData = JSON.parse( data ) as SSEvent[ 'data' ];
 
-			const { message = '', status: eventStatus } = eventData;
+			const { status: eventStatus } = eventData;
+			const message =
+				typeof eventData.message === 'string' ? eventData.message : '';
 
 			const newState = {
 				...upgradeState,
@@ -345,6 +347,7 @@ const UpgradeView = () => {
 					{ showLogs && (
 						<div className="upgrade-progress__logs">
 							<div className="upgrade-progress__logs__content">
+								{ /* Keep SSE messages in React text nodes so markup is escaped. */ }
 								{ logs.map( ( log, index ) => (
 									<div key={ index }>{ log }</div>
 								) ) }

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Content Control - The Ultimate Content Restriction Plugin! Restrict Content, Create Conditional Blocks & More ===
+=== Content Control - The Ultimate Content Restriction Solution! Restrict Content, Create Conditional Blocks & More ===
 Contributors: codeatlantic, danieliser
 Plugin URI: https://code-atlantic.com/?utm_campaign=upgrade-to-pro&utm_source=plugins-page&utm_medium=plugin-ui&utm_content=action-links-upgrade-text
 Author URI: https://contentcontrolplugin.com/?utm_campaign=plugin-info&utm_source=readme-header&utm_medium=plugin-ui&utm_content=author-uri

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source
 Tags: membership, access control, members only, content restriction, maintenance mode
 Requires at least: 6.2
 Tested up to: 7.1
-Stable tag: 2.7.0
+Stable tag: 2.7.1
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 
@@ -109,6 +109,12 @@ Bugs can be reported either in our support forum or we are happy to accept PRs o
 8. Restrict widgets as well.
 
 == Changelog ==
+
+= v2.7.1 - 08/20/2026 =
+
+* Security: Hardened administrative REST endpoints and request validation.
+* Fix: Corrected handling of encoded query parameters in restriction return URLs.
+* Compatibility: Improved BetterDocs searches and filtered block-control styles.
 
 = v2.7.0 - 08/20/2026 =
 

--- a/tests/unit/Classes/BetterDocs.php
+++ b/tests/unit/Classes/BetterDocs.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * BetterDocs compatibility tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use Brain\Monkey\Functions;
+use ContentControl\Controllers\Compatibility\BetterDocs as BetterDocsController;
+use ContentControl\Tests\PluginTestCase;
+
+/**
+ * BetterDocs compatibility behavior.
+ */
+class BetterDocs extends PluginTestCase {
+
+	/**
+	 * Forced post-type delimiters are preserved until each value is sanitized.
+	 */
+	public function test_forced_post_types_are_split_before_key_sanitization() {
+		global $wp;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture for WordPress request state.
+		$wp                    = (object) [ 'query_vars' => [ 'rest_route' => '/wp/v2/search' ] ];
+		$_REQUEST['post_type'] = 'ct_forced_docs:page';
+
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->returnArg();
+		Functions\when( 'sanitize_key' )->alias( static function ( $value ) {
+			return preg_replace( '/[^a-z0-9_\-]/', '', strtolower( $value ) );
+		} );
+
+		$controller = new BetterDocsController( new \stdClass() );
+		$intent     = $controller->get_rest_api_intent( [
+			'type' => 'unknown',
+			'name' => 'search',
+		] );
+
+		$this->assertSame( 'post_type', $intent['type'] );
+		$this->assertSame( [ 'docs', 'page' ], $intent['name'] );
+	}
+
+	/**
+	 * Clear request globals changed by the test.
+	 */
+	protected function tearDown(): void {
+		unset( $_REQUEST['post_type'] );
+		parent::tearDown();
+	}
+}

--- a/tests/unit/Classes/Blocks.php
+++ b/tests/unit/Classes/Blocks.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * Block controller tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use Brain\Monkey\Functions;
+use ContentControl\Controllers\Frontend\Blocks as BlocksController;
+use ContentControl\Tests\PluginTestCase;
+
+/**
+ * Frontend block behavior.
+ */
+class Blocks extends PluginTestCase {
+
+	/**
+	 * Inline styles preserve valid HTML-like CSS syntax.
+	 */
+	public function test_inline_styles_preserve_svg_data_uris() {
+		$container  = new class() {
+			public function get( $key ) {
+				return 'version' === $key ? '2.7.0' : null;
+			}
+		};
+		$controller = new class( $container ) extends BlocksController {
+			public function enqueue_styles( $styles ) {
+				$this->enqueue_block_styles( $styles );
+			}
+		};
+		$styles     = '.icon { background-image: url("data:image/svg+xml,<svg viewBox=\'0 0 1 1\'></svg>"); }';
+
+		Functions\expect( 'wp_register_style' )
+			->once()
+			->with( 'content-control-block-styles', false, [], '2.7.0' );
+		Functions\expect( 'wp_enqueue_style' )
+			->once()
+			->with( 'content-control-block-styles' );
+		Functions\expect( 'wp_add_inline_style' )
+			->once()
+			->with( 'content-control-block-styles', $styles );
+
+		$controller->enqueue_styles( $styles );
+	}
+}

--- a/tests/unit/Classes/Shortcodes.php
+++ b/tests/unit/Classes/Shortcodes.php
@@ -39,7 +39,8 @@ class Shortcodes extends TestCase {
 			return $value;
 		} );
 		Functions\when( 'wp_kses_post' )->alias( static function ( $value ) {
-			return $value;
+			unset( $value );
+			return '[sanitized]';
 		} );
 		Functions\when( 'esc_attr' )->alias( static function ( $value ) {
 			return $value;
@@ -71,5 +72,22 @@ class Shortcodes extends TestCase {
 		$this->assertStringStartsWith( '<span ', $controller->content_control( [ 'inline' ], 'Visible' ) );
 		$this->assertStringStartsWith( '<span ', $controller->content_control( [ 'inline' => 'true' ], 'Visible' ) );
 		$this->assertStringStartsWith( '<div ', $controller->content_control( [ 'inline' => 'false' ], 'Visible' ) );
+	}
+
+	/**
+	 * Allowed nested shortcode output is not passed through post KSES.
+	 */
+	public function test_allowed_nested_shortcode_html_is_preserved() {
+		$controller = new ShortcodesController(
+			new class() {
+				public function get_option( $key, $fallback = '' ) {
+					unset( $key );
+					return $fallback;
+				}
+			}
+		);
+		$content    = '<form><input type="text"><iframe></iframe><svg></svg><script>window.example = true;</script></form>';
+
+		$this->assertStringContainsString( $content, $controller->content_control( [], $content ) );
 	}
 }

--- a/tests/unit/Classes/Stream.php
+++ b/tests/unit/Classes/Stream.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * Stream controller tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use ContentControl\Base\Stream as StreamController;
+use ContentControl\Tests\TestCase;
+
+/**
+ * Server-sent event stream behavior.
+ */
+class Stream extends TestCase {
+
+	/**
+	 * Payload lines cannot inject additional SSE fields.
+	 */
+	public function test_payload_lines_are_framed_as_data_fields() {
+		$controller = new class() extends StreamController {
+			/**
+			 * Skip the WordPress-dependent stream-name setup for this formatter test.
+			 */
+			public function __construct() {}
+
+			/**
+			 * Expose the protected formatter for testing.
+			 *
+			 * @param string $data Data to format.
+			 *
+			 * @return string
+			 */
+			public function format( $data ) {
+				return $this->format_data( $data );
+			}
+		};
+
+		$payload = '</script><img src=x onerror=alert(1)>' . "\r\nevent: injected\n\ndata: forged";
+
+		$this->assertSame(
+			'data: </script><img src=x onerror=alert(1)>' . PHP_EOL .
+			'data: event: injected' . PHP_EOL .
+			'data: ' . PHP_EOL .
+			'data: data: forged' . PHP_EOL,
+			$controller->format( $payload )
+		);
+	}
+}

--- a/tests/unit/Functions/Content.php
+++ b/tests/unit/Functions/Content.php
@@ -1,0 +1,72 @@
+<?php
+/**
+ * Content function tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Functions;
+
+use Brain\Monkey\Functions;
+use ContentControl\Tests\PluginTestCase;
+use Mockery;
+
+use function ContentControl\get_current_page_url;
+
+/**
+ * Content helper behavior.
+ */
+class Content extends PluginTestCase {
+
+	/**
+	 * Encoded query values are decoded before their values are sanitized.
+	 */
+	public function test_current_page_url_preserves_percent_encoded_query_values() {
+		global $wp;
+
+		// phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited -- Test fixture for WordPress request state.
+		$wp                      = (object) [ 'request' => 'search' ];
+		$_SERVER['QUERY_STRING'] = 's=hello%20world&filter%5Bstatus%5D=published';
+
+		Functions\when( 'home_url' )->alias( static function ( $path ) {
+			return 'https://example.com/' . ltrim( $path, '/' );
+		} );
+		Functions\when( 'trailingslashit' )->alias( static function ( $url ) {
+			return rtrim( $url, '/' ) . '/';
+		} );
+		Functions\when( 'wp_unslash' )->returnArg();
+		Functions\when( 'sanitize_text_field' )->alias( static function ( $value ) {
+			return preg_replace( '/%[a-f0-9]{2}/i', '', $value );
+		} );
+		Functions\expect( 'wp_parse_str' )
+			->once()
+			->with(
+				's=hello%20world&filter%5Bstatus%5D=published',
+				Mockery::type( 'array' )
+			);
+		Functions\when( 'map_deep' )->alias( static function ( $values, $callback ) {
+			$sanitize = static function ( $value ) use ( &$sanitize, $callback ) {
+				if ( is_array( $value ) ) {
+					return array_map( $sanitize, $value );
+				}
+
+				return $callback( $value );
+			};
+
+			return $sanitize( $values );
+		} );
+		Functions\when( 'add_query_arg' )->alias( static function ( $args, $url ) {
+			return $url . '?' . http_build_query( $args );
+		} );
+
+		$this->assertSame( 'https://example.com/search/?', get_current_page_url() );
+	}
+
+	/**
+	 * Clear request globals changed by the test.
+	 */
+	protected function tearDown(): void {
+		unset( $_SERVER['QUERY_STRING'] );
+		parent::tearDown();
+	}
+}


### PR DESCRIPTION
## Summary

- ship the WordPress.org review remediation from #121 and #122
- publish user-facing security, URL handling, and compatibility notes
- update release metadata to 2.7.1

## Verification

- PHPCS
- PHPStan
- focused regression suite (BetterDocs, blocks, shortcodes, SSE, current URL)
- production release build
- release-tree and ZIP artifact verification (227 entries)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated to version 2.7.1.
  - Improved compatibility with BetterDocs search.
  - Preserved encoded query parameters in restriction return URLs.
  - Improved block-control style handling, including SVG data.
  - Added `composer.json` to release packages.

- **Bug Fixes**
  - Hardened administrative requests, REST endpoints, nonces, and permissions.
  - Improved Server-Sent Events message handling and security.
  - Strengthened validation of request and routing values.

- **Documentation**
  - Updated the README and changelog with the 2.7.1 release details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->