### PR TITLE
Release 2.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v2.7.2 - 08/26/2026
+
+-   Improvement: Refined request-scoped upgrade stream initialization for broader hosting compatibility.
+
 ## v2.7.1 - 08/20/2026
 
 -   Security: Hardened administrative REST endpoints and request validation.

--- a/classes/Base/Stream.php
+++ b/classes/Base/Stream.php
@@ -67,7 +67,6 @@ class Stream {
 		// phpcs:disable WordPress.PHP.IniSet.Risky, WordPress.PHP.NoSilencedErrors.Discouraged
 		@ini_set( 'zlib.output_compression', '0' );
 		@ini_set( 'implicit_flush', '1' );
-		@ini_set( 'log_limit', '8096' );
 
 		@ob_end_clean();
 		set_time_limit( 0 );

--- a/content-control.php
+++ b/content-control.php
@@ -3,7 +3,7 @@
  * Plugin Name: Content Control
  * Plugin URI: https://contentcontrolplugin.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=plugin-uri
  * Description: Restrict content to logged in/out users or specific user roles. Restrict access to certain parts of a page/post. Control the visibility of widgets.
- * Version: 2.7.1
+ * Version: 2.7.2
  * Author: Code Atlantic
  * Author URI: https://code-atlantic.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=author-uri
  * Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=donate-link
@@ -32,7 +32,7 @@ function get_plugin_config() {
 	return [
 		'name'          => 'Content Control',
 		'slug'          => 'content-control',
-		'version'       => '2.7.1',
+		'version'       => '2.7.2',
 		'option_prefix' => 'content_control',
 		// Maybe remove this and simply prefix `name` with `'Popup Maker'`.
 		'text_domain'   => 'content-control',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "content-control",
-	"version": "2.7.1",
+	"version": "2.7.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "content-control",
-			"version": "2.7.1",
+			"version": "2.7.2",
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "content-control",
-	"version": "2.7.1",
+	"version": "2.7.2",
 	"description": "",
 	"author": "Code Atlantic LLC",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source
 Tags: membership, access control, members only, content restriction, maintenance mode
 Requires at least: 6.2
 Tested up to: 7.1
-Stable tag: 2.7.1
+Stable tag: 2.7.2
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 
@@ -109,6 +109,10 @@ Bugs can be reported either in our support forum or we are happy to accept PRs o
 8. Restrict widgets as well.
 
 == Changelog ==
+
+= v2.7.2 - 08/26/2026 =
+
+* Improvement: Refined request-scoped upgrade stream initialization for broader hosting compatibility.
 
 = v2.7.1 - 08/20/2026 =
 


### PR DESCRIPTION
## Summary

- remove the ineffective PHP-FPM log_limit call from request-scoped stream initialization
- prepare Content Control 2.7.2 release metadata and changelog

## Verification

- PHPCS passes
- production release build passes
- release artifact verifier passes (184 entries)
- legacy unit suite has four pre-existing PHP 8.5 failures unrelated to Stream.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved request-scoped upgrade stream initialization for broader hosting compatibility.
  - Prevented unnecessary PHP logging configuration changes during stream startup.

- **Chores**
  - Updated the Content Control version to 2.7.2.
  - Added release documentation for version 2.7.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->