### PR TITLE
Release 2.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## v2.7.3 - 09/01/2026
+
+-   Fix: Direct Content Control Pro customers to the appropriate product review form.
+
 ## v2.7.2 - 08/26/2026
 
 -   Improvement: Refined request-scoped upgrade stream initialization for broader hosting compatibility.

--- a/classes/Controllers/Admin/Reviews.php
+++ b/classes/Controllers/Admin/Reviews.php
@@ -271,7 +271,7 @@ class Reviews extends Controller {
 		static $triggers;
 
 		if ( ! isset( $triggers ) ) {
-			$link = 'https://wordpress.org/support/plugin/content-control/reviews/?rate=5#rate-response';
+			$link = $this->get_review_link();
 
 			// Translators: 1. emoji, 2. html tag, 3. html tag, 4. the number of days, 5. html tag, 6. html tag.
 			$time_message = __( 'Hi there! %1$s You\'ve been using the %2$sContent Control%3$s plugin on your site for %4$s now - We hope it\'s been helpful. If you\'re enjoying the plugin, would you mind rating it %5$s5-stars%6$s to help spread the word?', 'content-control' );
@@ -356,6 +356,23 @@ class Reviews extends Controller {
 		}
 
 		return $triggers;
+	}
+
+	/**
+	 * Get the review destination for the installed product.
+	 *
+	 * Free users go directly to WordPress.org's unselected review form. Sites
+	 * with Pro installed use the first-party landing page, which routes them to
+	 * the verified-purchaser review form for the commercial product.
+	 *
+	 * @since 2.7.3
+	 *
+	 * @return string
+	 */
+	public function get_review_link() {
+		return $this->container->is_pro_installed()
+			? 'https://contentcontrolplugin.com/leave-a-review/?product=pro'
+			: 'https://wordpress.org/support/plugin/content-control/reviews/#rate-response';
 	}
 
 	/**

--- a/content-control.php
+++ b/content-control.php
@@ -3,7 +3,7 @@
  * Plugin Name: Content Control
  * Plugin URI: https://contentcontrolplugin.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=plugin-uri
  * Description: Restrict content to logged in/out users or specific user roles. Restrict access to certain parts of a page/post. Control the visibility of widgets.
- * Version: 2.7.2
+ * Version: 2.7.3
  * Author: Code Atlantic
  * Author URI: https://code-atlantic.com/?utm_campaign=plugin-info&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=author-uri
  * Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source=php-file-header&utm_medium=plugin-ui&utm_content=donate-link
@@ -32,7 +32,7 @@ function get_plugin_config() {
 	return [
 		'name'          => 'Content Control',
 		'slug'          => 'content-control',
-		'version'       => '2.7.2',
+		'version'       => '2.7.3',
 		'option_prefix' => 'content_control',
 		// Maybe remove this and simply prefix `name` with `'Popup Maker'`.
 		'text_domain'   => 'content-control',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "content-control",
-	"version": "2.7.2",
+	"version": "2.7.3",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "content-control",
-			"version": "2.7.2",
+			"version": "2.7.3",
 			"license": "GPL-2.0-or-later",
 			"workspaces": [
 				"./packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "content-control",
-	"version": "2.7.2",
+	"version": "2.7.3",
 	"description": "",
 	"author": "Code Atlantic LLC",
 	"license": "GPL-2.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Donate link: https://code-atlantic.com/donate/?utm_campaign=donations&utm_source
 Tags: membership, access control, members only, content restriction, maintenance mode
 Requires at least: 6.2
 Tested up to: 7.1
-Stable tag: 2.7.2
+Stable tag: 2.7.3
 Requires PHP: 7.4
 License: GPL-2.0-or-later
 
@@ -109,6 +109,10 @@ Bugs can be reported either in our support forum or we are happy to accept PRs o
 8. Restrict widgets as well.
 
 == Changelog ==
+
+= v2.7.3 - 09/01/2026 =
+
+* Fix: Direct Content Control Pro customers to the appropriate product review form.
 
 = v2.7.2 - 08/26/2026 =
 

--- a/tests/unit/Classes/AdminReviews.php
+++ b/tests/unit/Classes/AdminReviews.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Admin review controller tests.
+ *
+ * @package ContentControl\Tests
+ */
+
+namespace ContentControl\Tests\Classes;
+
+use ContentControl\Controllers\Admin\Reviews;
+use ContentControl\Tests\TestCase;
+
+/**
+ * Product-aware review destinations.
+ */
+class AdminReviews extends TestCase {
+
+	/**
+	 * Free installations use WordPress.org without preselecting a rating.
+	 */
+	public function test_free_review_link_uses_unselected_wordpress_form() {
+		$controller = new Reviews( $this->create_container( false ) );
+
+		$this->assertSame(
+			'https://wordpress.org/support/plugin/content-control/reviews/#rate-response',
+			$controller->get_review_link()
+		);
+	}
+
+	/**
+	 * Pro installations use the first-party verified-customer review route.
+	 */
+	public function test_pro_review_link_uses_product_landing_page() {
+		$controller = new Reviews( $this->create_container( true ) );
+
+		$this->assertSame(
+			'https://contentcontrolplugin.com/leave-a-review/?product=pro',
+			$controller->get_review_link()
+		);
+	}
+
+	/**
+	 * Create the minimum Core container contract required by the controller.
+	 *
+	 * @param bool $pro_installed Whether Pro is installed.
+	 *
+	 * @return object
+	 */
+	private function create_container( $pro_installed ) {
+		return new class( $pro_installed ) {
+			/**
+			 * Whether Pro is installed.
+			 *
+			 * @var bool
+			 */
+			private $pro_installed;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param bool $pro_installed Whether Pro is installed.
+			 */
+			public function __construct( $pro_installed ) {
+				$this->pro_installed = $pro_installed;
+			}
+
+			/**
+			 * Match the Core container API.
+			 *
+			 * @return bool
+			 */
+			public function is_pro_installed() {
+				return $this->pro_installed;
+			}
+		};
+	}
+}


### PR DESCRIPTION
## Summary

- route the free Core review CTA to the unselected WordPress.org submission form
- route Pro-installed sites to the verified-purchaser review flow for Content Control Pro
- add focused route coverage and prepare the 2.7.3 release metadata

## Verification

- focused review-route unit tests pass (2 tests, 2 assertions)
- PHPCS passes
- PHPStan passes
- production release build passes
- release artifact verifier passes (184 entries)
- live review landing page verified at desktop and mobile sizes; its optional redirect timer is present but disabled
- legacy full unit suite retains four pre-existing PHP 8.5 failures unrelated to this change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Review prompts now direct Pro customers to the appropriate product review page.
  * Free installations continue linking to the WordPress.org review form.

* **Release**
  * Updated the plugin to version 2.7.3.
  * Added changelog and readme notes for the review-link fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->